### PR TITLE
Release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTPXMock.get_request now fails if more than one request match. Use HTTPXMock.get_request instead.
 - HTTPXMock.requests is now private, use HTTPXMock.get_requests instead.
 - HTTPXMock.responses is now private, it should not be accessed anyway.
+- url can now be a re.Pattern instance.
 
 ## [0.0.2] - 2020-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.3] - 2020-02-06
 ### Added
 - Allow to provide JSON response as python values.
+- Mock async httpx requests as well.
 
-### Fixed
+### Changed
 - method can now be provided even if not entirely upper cased.
 
 ## [0.0.2] - 2020-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow to provide JSON response as python values.
 - Mock async httpx requests as well.
+- Allow to provide files and boundary for multipart response.
+- Allow to provide data as a dictionary for multipart response.
 
 ### Changed
 - method can now be provided even if not entirely upper cased.
+- content parameter renamed into data.
 
 ## [0.0.2] - 2020-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mock async httpx requests as well.
 - Allow to provide files and boundary for multipart response.
 - Allow to provide data as a dictionary for multipart response.
+- Allow to provide callbacks that are executed upon reception of a request.
 
 ### Changed
 - method can now be provided even if not entirely upper cased.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - method can now be provided even if not entirely upper cased.
 - content parameter renamed into data.
+- HTTPXMock.requests is now private, use HTTPXMock.get_request instead.
+- HTTPXMock.responses is now private, it should not be accessed anyway.
 
 ## [0.0.2] - 2020-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2020-02-06
+### Added
+- Allow to provide JSON response as python values.
+
+### Fixed
+- method can now be provided even if not entirely upper cased.
+
 ## [0.0.2] - 2020-02-06
 ### Added
 - Allow to retrieve requests.
@@ -14,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/Colin-b/pytest_httpx/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to provide files and boundary for multipart response.
 - Allow to provide data as a dictionary for multipart response.
 - Allow to provide callbacks that are executed upon reception of a request.
+- Handle the fact that parameters may be introduced in httpx *Dispatcher.send method.
 
 ### Changed
 - method can now be provided even if not entirely upper cased.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to provide data as a dictionary for multipart response.
 - Allow to provide callbacks that are executed upon reception of a request.
 - Handle the fact that parameters may be introduced in httpx *Dispatcher.send method.
+- Allow to retrieve all matching requests with HTTPXMock.get_requests
 
 ### Changed
 - method can now be provided even if not entirely upper cased.
 - content parameter renamed into data.
-- HTTPXMock.requests is now private, use HTTPXMock.get_request instead.
+- HTTPXMock.get_request now fails if more than one request match. Use HTTPXMock.get_request instead.
+- HTTPXMock.requests is now private, use HTTPXMock.get_requests instead.
 - HTTPXMock.responses is now private, it should not be accessed anyway.
 
 ## [0.0.2] - 2020-02-06

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Notice: This module is still under development, versions prior to 1.0.0 are subj
 
 Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture to mock [`httpx`](https://www.python-httpx.org) requests.
 
+- [Add responses](#add-responses)
+  - [JSON body](#add-json-response)
+  - [Custom body](#reply-with-custom-body)
+  - [HTTP method](#add-non-get-response)
+  - [HTTP status code](#add-non-200-response)
+  - [HTTP headers](#reply-with-custom-headers)
+  - [HTTP/2.0](#add-http/2.0-response)
+- [Check requests](#check-sent-requests)
 
 ## Add responses
 
@@ -34,6 +42,136 @@ First response will be sent as response of the first request and so on.
 If the number of responses is lower than the number of requests on an URL, the last response will be used to reply to all subsequent requests on this URL.
 
 If all responses are not sent back during test execution, the test case will fail at teardown.
+
+Default response is a 200 (OK) without any body for a GET request on the provided URL using HTTP/1.1 protocol version.
+
+Default matching is performed on the full URL, query parameters included.
+
+### Add JSON response
+
+Use `json` parameter to add a JSON response using python values.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", json=[{"key1": "value1", "key2": "value2"}])
+
+    assert httpx.get("http://test_url").json() == [{"key1": "value1", "key2": "value2"}]
+    
+```
+
+### Reply with custom body
+
+Use `content` parameter to reply with a custom body by providing bytes or UTF-8 encoded string.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_str_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", content="This is my UTF-8 content")
+
+    assert httpx.get("http://test_url").text == "This is my UTF-8 content"
+
+
+def test_bytes_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", content=b"This is my bytes content")
+
+    assert httpx.get("http://test_url").content == b"This is my bytes content"
+    
+```
+
+### Add non GET response
+
+Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) to reply to on provided URL.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_post(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="POST")
+
+    response = httpx.post("http://test_url")
+
+
+def test_put(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="PUT")
+
+    response = httpx.put("http://test_url")
+
+
+def test_delete(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="DELETE")
+
+    response = httpx.delete("http://test_url")
+
+
+def test_patch(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="PATCH")
+
+    response = httpx.patch("http://test_url")
+
+
+def test_head(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="HEAD")
+
+    response = httpx.head("http://test_url")
+    
+```
+
+### Add non 200 response
+
+Use `status_code` parameter to specify the HTTP status code of the response.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", status_code=404)
+
+    assert httpx.get("http://test_url").status_code == 404
+
+```
+
+### Reply with custom headers
+
+Use `headers` parameter to specify the extra headers of the response.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", headers={"X-Header1": "Test value"})
+
+    assert httpx.get("http://test_url").headers["x-header1"] == "Test value"
+
+```
+
+### Add HTTP/2.0 response
+
+Use `http_version` parameter to specify the HTTP protocol version of the response.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", http_version="HTTP/2.0")
+
+    assert httpx.get("http://test_url").http_version == "HTTP/2.0"
+
+```
 
 ## Check sent requests
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
   - [HTTP status code](#add-non-200-response)
   - [HTTP headers](#reply-with-custom-headers)
   - [HTTP/2.0](#add-http/2.0-response)
-  - [Callback and exception throwing](#callback)
+- [Add dynamic responses](#dynamic-responses)
+- [Raising exceptions](#raising-exceptions)
 - [Check requests](#check-sent-requests)
 
 ## Add responses
@@ -229,7 +230,7 @@ def test_something(httpx_mock: HTTPXMock):
 
 ```
 
-### Callback
+## Dynamic responses
 
 You can perform custom manipulation upon request reception by registering callbacks.
 
@@ -264,6 +265,8 @@ def test_something(httpx_mock: HTTPXMock):
         assert response.json() == {"url": "http://test_url"}
 
 ```
+
+## Raising exceptions
 
 You can simulate httpx exception throwing by raising an exception in your callback.
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,19 @@ async def test_something_async(httpx_mock: HTTPXMock):
         response = await client.get("http://test_url")
 ```
 
-In case more than one request is sent to the same URL, the responses will be sent in the registration order.
-
-First response will be sent as response of the first request and so on.
-
-If the number of responses is lower than the number of requests on an URL, the last response will be used to reply to all subsequent requests on this URL.
-
 If all responses are not sent back during test execution, the test case will fail at teardown.
 
 Default response is a 200 (OK) without any body for a GET request on the provided URL using HTTP/1.1 protocol version.
 
-Default matching is performed on the full URL, query parameters included.
+### How response is selected
+
+Default matching is performed on the full URL, query parameters included and the HTTP method.
+
+Registration order is kept while checking what response to send.
+
+In case more than one response match request, the first one not yet sent will be sent.
+
+In case all matching responses have been sent, the last registered one will be sent.
 
 ### Add JSON response
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-27 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-29 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -16,6 +16,7 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
 - [Add responses](#add-responses)
   - [JSON body](#add-json-response)
   - [Custom body](#reply-with-custom-body)
+  - [Multipart body (files, ...)](#add-multipart-response)
   - [HTTP method](#add-non-get-response)
   - [HTTP status code](#add-non-200-response)
   - [HTTP headers](#reply-with-custom-headers)
@@ -74,7 +75,7 @@ def test_something(httpx_mock: HTTPXMock):
 
 ### Reply with custom body
 
-Use `content` parameter to reply with a custom body by providing bytes or UTF-8 encoded string.
+Use `data` parameter to reply with a custom body by providing bytes or UTF-8 encoded string.
 
 ```python
 import httpx
@@ -82,15 +83,43 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_str_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content="This is my UTF-8 content")
+    httpx_mock.add_response("http://test_url", data="This is my UTF-8 content")
 
     assert httpx.get("http://test_url").text == "This is my UTF-8 content"
 
 
 def test_bytes_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content=b"This is my bytes content")
+    httpx_mock.add_response("http://test_url", data=b"This is my bytes content")
 
     assert httpx.get("http://test_url").content == b"This is my bytes content"
+    
+```
+
+### Add multipart response
+
+Use `data` parameter as a dictionary or `files` parameter (or both) to send multipart response.
+
+You can specify `boundary` parameter to specify the multipart boundary to use.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_multipart_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", data={"key1": "value1"}, files={"file1": "content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
+
+    assert httpx.get("http://test_url").text == '''--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="key1"\r
+\r
+value1\r
+--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="file1"; filename="upload"\r
+Content-Type: application/octet-stream\r
+\r
+content of file 1\r
+--2256d3a36d2a61a1eba35a22bee5c74a--\r
+'''
     
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-36 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-44 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -63,6 +63,10 @@ Registration order is kept while checking what response to send.
 In case more than one response match request, the first one not yet sent will be sent.
 
 In case all matching responses have been sent, the last registered one will be sent.
+
+#### Providing URL
+
+URL can either be a string, a python re.Pattern instance or a httpx.URL instance.
 
 ### Add JSON response
 
@@ -247,15 +251,13 @@ Default callback is for a GET request on the provided URL.
 Callback should return a httpx.Response instance.
 
 ```python
-from typing import Optional
-
 import httpx
 from httpx import content_streams
 from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_dynamic_response(httpx_mock: HTTPXMock):
-    def custom_response(request: httpx.Request, timeout: Optional[httpx.Timeout]) -> httpx.Response:
+    def custom_response(request: httpx.Request, *args, **kwargs) -> httpx.Response:
         return httpx.Response(
             status_code=200,
             http_version="HTTP/1.1",
@@ -279,15 +281,13 @@ You can simulate httpx exception throwing by raising an exception in your callba
 This can be useful if you want to assert that your code handles httpx exceptions properly.
 
 ```python
-from typing import Optional
-
 import httpx
 import pytest
 from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_exception_raising(httpx_mock: HTTPXMock):
-    def raise_timeout(request: httpx.Request, timeout: Optional[httpx.Timeout]) -> httpx.Response:
+    def raise_timeout(*args, **kwargs) -> httpx.Response:
         raise httpx.exceptions.TimeoutException()
 
     httpx_mock.add_callback(raise_timeout, "http://test_url")
@@ -307,6 +307,10 @@ Registration order is kept while checking what callback to execute.
 In case more than one callback match request, the first one not yet executed will be sent.
 
 In case all matching callbacks have been sent, the last registered one will be sent.
+
+#### Providing URL
+
+URL can either be a string, a python re.Pattern instance or a httpx.URL instance.
 
 ## Check sent requests
 
@@ -339,3 +343,7 @@ def test_single_request(httpx_mock: HTTPXMock):
 Default matching is performed on the full URL, query parameters included and the HTTP method.
 
 Request original order is kept while appending to the list.
+
+#### Providing URL
+
+URL can either be a string, a python re.Pattern instance or a httpx.URL instance.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-29 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-34 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
 Notice: This module is still under development, versions prior to 1.0.0 are subject to breaking changes without notice.
 
-Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture to mock [`httpx`](https://www.python-httpx.org) requests (sync or async).
+Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture to mock [`httpx`](https://www.python-httpx.org) requests.
 
 - [Add responses](#add-responses)
   - [JSON body](#add-json-response)
@@ -21,9 +21,12 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
   - [HTTP status code](#add-non-200-response)
   - [HTTP headers](#reply-with-custom-headers)
   - [HTTP/2.0](#add-http/2.0-response)
+  - [Callback and exception throwing](#callback)
 - [Check requests](#check-sent-requests)
 
 ## Add responses
+
+You can register responses for both sync and async `httpx` requests.
 
 ```python
 import pytest
@@ -34,7 +37,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
-    response = httpx.get("http://test_url")
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
 
 
 @pytest.mark.asyncio
@@ -69,7 +73,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", json=[{"key1": "value1", "key2": "value2"}])
 
-    assert httpx.get("http://test_url").json() == [{"key1": "value1", "key2": "value2"}]
+    with httpx.Client() as client:
+        assert client.get("http://test_url").json() == [{"key1": "value1", "key2": "value2"}]
     
 ```
 
@@ -85,13 +90,15 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_str_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", data="This is my UTF-8 content")
 
-    assert httpx.get("http://test_url").text == "This is my UTF-8 content"
+    with httpx.Client() as client:
+        assert client.get("http://test_url").text == "This is my UTF-8 content"
 
 
 def test_bytes_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", data=b"This is my bytes content")
 
-    assert httpx.get("http://test_url").content == b"This is my bytes content"
+    with httpx.Client() as client:
+        assert client.get("http://test_url").content == b"This is my bytes content"
     
 ```
 
@@ -109,7 +116,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_multipart_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", data={"key1": "value1"}, files={"file1": "content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
 
-    assert httpx.get("http://test_url").text == '''--2256d3a36d2a61a1eba35a22bee5c74a\r
+    with httpx.Client() as client:
+        assert client.get("http://test_url").text == '''--2256d3a36d2a61a1eba35a22bee5c74a\r
 Content-Disposition: form-data; name="key1"\r
 \r
 value1\r
@@ -135,31 +143,36 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_post(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", method="POST")
 
-    response = httpx.post("http://test_url")
+    with httpx.Client() as client:
+        response = client.post("http://test_url")
 
 
 def test_put(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", method="PUT")
 
-    response = httpx.put("http://test_url")
+    with httpx.Client() as client:
+        response = client.put("http://test_url")
 
 
 def test_delete(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", method="DELETE")
 
-    response = httpx.delete("http://test_url")
+    with httpx.Client() as client:
+        response = client.delete("http://test_url")
 
 
 def test_patch(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", method="PATCH")
 
-    response = httpx.patch("http://test_url")
+    with httpx.Client() as client:
+        response = client.patch("http://test_url")
 
 
 def test_head(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", method="HEAD")
 
-    response = httpx.head("http://test_url")
+    with httpx.Client() as client:
+        response = client.head("http://test_url")
     
 ```
 
@@ -175,7 +188,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", status_code=404)
 
-    assert httpx.get("http://test_url").status_code == 404
+    with httpx.Client() as client:
+        assert client.get("http://test_url").status_code == 404
 
 ```
 
@@ -191,7 +205,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", headers={"X-Header1": "Test value"})
 
-    assert httpx.get("http://test_url").headers["x-header1"] == "Test value"
+    with httpx.Client() as client:
+        assert client.get("http://test_url").headers["x-header1"] == "Test value"
 
 ```
 
@@ -207,9 +222,82 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", http_version="HTTP/2.0")
 
-    assert httpx.get("http://test_url").http_version == "HTTP/2.0"
+    with httpx.Client() as client:
+        assert client.get("http://test_url").http_version == "HTTP/2.0"
 
 ```
+
+### Callback
+
+You can perform custom manipulation upon request reception by registering callbacks.
+
+Callback should expect at least two parameters:
+ * request: The received request.
+ * timeout: The timeout linked to the request.
+
+Callback should return a httpx.Response instance.
+
+```python
+from typing import Optional
+
+import httpx
+from httpx import content_streams
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    def custom_response(request: httpx.Request, timeout: Optional[httpx.Timeout]) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            http_version="HTTP/1.1",
+            headers=[],
+            stream=content_streams.JSONStream({"url": str(request.url)}),
+            request=request,
+        )
+
+    httpx_mock.add_callback(custom_response, "http://test_url")
+
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.json() == {"url": "http://test_url"}
+
+```
+
+You can simulate httpx exception throwing by raising an exception in your callback.
+
+This can be useful if you want to assert that your code handles httpx exceptions properly.
+
+```python
+from typing import Optional
+
+import httpx
+import pytest
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_something(httpx_mock: HTTPXMock):
+    def raise_timeout(request: httpx.Request, timeout: Optional[httpx.Timeout]) -> httpx.Response:
+        raise httpx.exceptions.TimeoutException()
+
+    httpx_mock.add_callback(raise_timeout, "http://test_url")
+    
+    with httpx.Client() as client:
+        with pytest.raises(httpx.exceptions.TimeoutException):
+            client.get("http://test_url")
+
+```
+
+In case more than one request is sent to the same URL, the callbacks will be called in the registration order.
+
+First callback will be called upon reception of the first request and so on.
+
+If the number of callbacks is lower than the number of requests on an URL, the last callback will be called for each subsequent requests on this URL.
+
+If all callbacks are not executed during test execution, the test case will fail at teardown.
+
+Default callback is for a GET request on the provided URL.
+
+Default matching is performed on the full URL, query parameters included.
 
 ## Check sent requests
 
@@ -221,7 +309,8 @@ from pytest_httpx import httpx_mock, HTTPXMock
 def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
-    response = httpx.get("http://test_url")
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
 
     request = httpx_mock.get_request("http://test_url")
 ```

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-14 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-27 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
 Notice: This module is still under development, versions prior to 1.0.0 are subject to breaking changes without notice.
 
-Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture to mock [`httpx`](https://www.python-httpx.org) requests.
+Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture to mock [`httpx`](https://www.python-httpx.org) requests (sync or async).
 
 - [Add responses](#add-responses)
   - [JSON body](#add-json-response)
@@ -25,6 +25,7 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
 ## Add responses
 
 ```python
+import pytest
 import httpx
 from pytest_httpx import httpx_mock, HTTPXMock
 
@@ -33,6 +34,14 @@ def test_something(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
     response = httpx.get("http://test_url")
+
+
+@pytest.mark.asyncio
+async def test_something_async(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
 ```
 
 In case more than one request is sent to the same URL, the responses will be sent in the registration order.

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,2 +1,4 @@
 from pytest_httpx.version import __version__
 from pytest_httpx._httpx_mock import httpx_mock, HTTPXMock
+
+# TODO Auto register fixture the way pytest-responses does

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -179,9 +179,7 @@ class HTTPXMock:
 
     def _assert_responses_sent(self):
         responses_not_called = [
-            response.url
-            for matcher, response in self._responses
-            if not matcher.nb_calls
+            response for matcher, response in self._responses if not matcher.nb_calls
         ]
         self._responses.clear()
         assert (

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -30,6 +30,7 @@ class HTTPXMock:
 
         :param url: Full URL identifying the request. Can be a str or httpx.URL instance.
         # TODO Allow non strict URL params checking
+        # TODO Allow regex in URL
         :param method: HTTP method identifying the request. Default to GET.
         :param status_code: HTTP status code of the response to send. Default to 200 (OK).
         :param http_version: HTTP protocol version of the response to send. Default to HTTP/1.1

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -163,7 +163,7 @@ class HTTPXMock:
         requests = self.get_requests(url, method)
         assert (
             len(requests) <= 1
-        ), "More than one request match, use get_requests instead."
+        ), f"More than one request ({len(requests)}) matched, use get_requests instead."
         return requests[0] if requests else None
 
     def _assert_responses_sent(self):

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -48,10 +48,11 @@ class HTTPXMock:
             )
         )
 
-    def _get_response(self, request: Request) -> Response:
+    def _get_response(self, request: Request, timeout: Optional[Timeout]) -> Response:
         self.requests.setdefault((request.method, request.url), []).append(request)
         responses = self.responses.get((request.method, request.url))
         if not responses:
+            # TODO raise TimeoutError() in case timeout is reached ?
             raise Exception(
                 f"No mock can be found for {request.method} request on {request.url}."
             )
@@ -93,7 +94,7 @@ class _PytestSyncDispatcher(SyncDispatcher):
         self.mock = mock
 
     def send(self, request: Request, timeout: Timeout = None) -> Response:
-        return self.mock._get_response(request)
+        return self.mock._get_response(request, timeout)
 
 
 @pytest.fixture

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -73,7 +73,6 @@ class HTTPXMock:
          * timeout: The timeout linked to the request.
         It should return an httpx.Response instance.
         :param url: Full URL identifying the request. Can be a str or httpx.URL instance.
-        # TODO Allow non strict URL params checking
         :param method: HTTP method identifying the request. Default to GET.
         """
         self._callbacks.append((_RequestMatcher(url, method), callback))

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,13 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Build Tools",
     ],
-    keywords=[
-        "pytest",
-        "testing",
-        "mock",
-        "httpx",
-    ],
+    keywords=["pytest", "testing", "mock", "httpx"],
     packages=find_packages(exclude=["tests*"]),
-    install_requires=[
-        "httpx==0.11.*",
-        "pytest==5.*",
-    ],
+    install_requires=["httpx==0.11.*", "pytest==5.*"],
     extras_require={
         "testing": [
+            # Used to run async test functions
+            "pytest-asyncio==0.10.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1,0 +1,351 @@
+import pytest
+import httpx
+
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_without_response(httpx_mock: HTTPXMock):
+    with pytest.raises(Exception) as exception_info:
+        async with httpx.AsyncClient() as client:
+            await client.get("http://test_url")
+    assert (
+        str(exception_info.value)
+        == "No mock can be found for GET request on http://test_url."
+    )
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_default_response(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+    assert response.content == b""
+    assert response.status_code == 200
+    assert response.headers == httpx.Headers({})
+    assert response.http_version == "HTTP/1.1"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", content=b"test content")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b"test content"
+
+        response = await client.get("http://test_url")
+        assert response.content == b"test content"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", content=b"test content 1")
+    httpx_mock.add_response("http://test_url", content=b"test content 2")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 1"
+
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 2"
+
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 2"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
+    httpx_mock.add_response(
+        "http://test_url", method="DELETE", content=b"test content 4"
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="PATCH", content=b"test content 5"
+    )
+    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://test_url")
+        assert response.content == b"test content 2"
+
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 1"
+
+        response = await client.put("http://test_url")
+        assert response.content == b"test content 3"
+
+        response = await client.head("http://test_url")
+        assert response.content == b"test content 6"
+
+        response = await client.patch("http://test_url")
+        assert response.content == b"test content 5"
+
+        response = await client.delete("http://test_url")
+        assert response.content == b"test content 4"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url", method="GET", content=b"test content 1", status_code=200
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="POST", content=b"test content 2", status_code=201
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="PUT", content=b"test content 3", status_code=202
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="DELETE", content=b"test content 4", status_code=303
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="PATCH", content=b"test content 5", status_code=404
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="HEAD", content=b"test content 6", status_code=500
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://test_url")
+        assert response.content == b"test content 2"
+        assert response.status_code == 201
+
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.status_code == 200
+
+        response = await client.put("http://test_url")
+        assert response.content == b"test content 3"
+        assert response.status_code == 202
+
+        response = await client.head("http://test_url")
+        assert response.content == b"test content 6"
+        assert response.status_code == 500
+
+        response = await client.patch("http://test_url")
+        assert response.content == b"test content 5"
+        assert response.status_code == 404
+
+        response = await client.delete("http://test_url")
+        assert response.content == b"test content 4"
+        assert response.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_many_responses_urls_str(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url?param1=test", method="GET", content=b"test content 1"
+    )
+    httpx_mock.add_response(
+        "http://test_url?param2=test", method="POST", content=b"test content 2"
+    )
+    httpx_mock.add_response(
+        "http://test_url?param3=test", method="PUT", content=b"test content 3"
+    )
+    httpx_mock.add_response(
+        "http://test_url?param4=test", method="DELETE", content=b"test content 4"
+    )
+    httpx_mock.add_response(
+        "http://test_url?param5=test", method="PATCH", content=b"test content 5"
+    )
+    httpx_mock.add_response(
+        "http://test_url?param6=test", method="HEAD", content=b"test content 6"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            httpx.URL("http://test_url", params={"param2": "test"})
+        )
+        assert response.content == b"test content 2"
+
+        response = await client.get(
+            httpx.URL("http://test_url", params={"param1": "test"})
+        )
+        assert response.content == b"test content 1"
+
+        response = await client.put(
+            httpx.URL("http://test_url", params={"param3": "test"})
+        )
+        assert response.content == b"test content 3"
+
+        response = await client.head(
+            httpx.URL("http://test_url", params={"param6": "test"})
+        )
+        assert response.content == b"test content 6"
+
+        response = await client.patch(
+            httpx.URL("http://test_url", params={"param5": "test"})
+        )
+        assert response.content == b"test content 5"
+
+        response = await client.delete(
+            httpx.URL("http://test_url", params={"param4": "test"})
+        )
+        assert response.content == b"test content 4"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param1": "test"}),
+        method="GET",
+        content=b"test content 1",
+    )
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param2": "test"}),
+        method="POST",
+        content=b"test content 2",
+    )
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param3": "test"}),
+        method="PUT",
+        content=b"test content 3",
+    )
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param4": "test"}),
+        method="DELETE",
+        content=b"test content 4",
+    )
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param5": "test"}),
+        method="PATCH",
+        content=b"test content 5",
+    )
+    httpx_mock.add_response(
+        httpx.URL("http://test_url", params={"param6": "test"}),
+        method="HEAD",
+        content=b"test content 6",
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://test_url?param2=test")
+        assert response.content == b"test content 2"
+
+        response = await client.get("http://test_url?param1=test")
+        assert response.content == b"test content 1"
+
+        response = await client.put("http://test_url?param3=test")
+        assert response.content == b"test content 3"
+
+        response = await client.head("http://test_url?param6=test")
+        assert response.content == b"test content 6"
+
+        response = await client.patch("http://test_url?param5=test")
+        assert response.content == b"test content 5"
+
+        response = await client.delete("http://test_url?param4=test")
+        assert response.content == b"test content 4"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url", http_version="HTTP/2", content=b"test content 1"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.http_version == "HTTP/2"
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url", content=b"test content 1", headers={"X-Test": "Test value"}
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.headers == httpx.Headers({"x-test": "Test value"})
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
+    httpx_mock.add_response(
+        "http://test_url", method="DELETE", content=b"test content 4"
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="PATCH", content=b"test content 5"
+    )
+    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+
+    async with httpx.AsyncClient() as client:
+        await client.post("http://test_url", data=b"sent content 2")
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.put("http://test_url", data=b"sent content 3")
+        await client.head("http://test_url")
+        await client.patch("http://test_url", data=b"sent content 5")
+        await client.delete("http://test_url", headers={"X-Test": "test header 4"})
+
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url"), "PATCH").read()
+        == b"sent content 5"
+    )
+    assert httpx_mock.get_request(httpx.URL("http://test_url"), "HEAD").read() == b""
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url"), "PUT").read()
+        == b"sent content 3"
+    )
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url")).headers["x-test"]
+        == "test header 1"
+    )
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url"), "POST").read()
+        == b"sent content 2"
+    )
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url"), "DELETE").headers["x-test"]
+        == "test header 4"
+    )
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_requests_retrieval_on_same_url_and_method(
+    httpx_mock: HTTPXMock,
+):
+    httpx_mock.add_response("http://test_url")
+
+    async with httpx.AsyncClient() as client:
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.get("http://test_url", headers={"X-TEST": "test header 2"})
+
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url")).headers["x-test"]
+        == "test header 1"
+    )
+    assert (
+        httpx_mock.get_request(httpx.URL("http://test_url")).headers["x-test"]
+        == "test header 2"
+    )
+    assert not httpx_mock.get_request(httpx.URL("http://test_url"))
+
+
+@pytest.mark.asyncio
+async def test_httpx_mock_requests_json_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url", json=["list content 1", "list content 2"]
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="POST", json={"key 1": "value 1", "key 2": "value 2"}
+    )
+    httpx_mock.add_response("http://test_url", method="PUT", json="string value")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://test_url")
+        assert response.json() == {"key 1": "value 1", "key 2": "value 2"}
+
+        response = await client.get("http://test_url")
+        assert response.json() == ["list content 1", "list content 2"]
+
+        response = await client.put("http://test_url")
+        assert response.json() == "string value"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -29,7 +29,7 @@ async def test_httpx_mock_default_response(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content=b"test content")
+    httpx_mock.add_response("http://test_url", data=b"test content")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -41,8 +41,8 @@ async def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", content=b"test content 2")
+    httpx_mock.add_response("http://test_url", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", data=b"test content 2")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -57,16 +57,12 @@ async def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
-    httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4"
-    )
-    httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5"
-    )
-    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
+    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
+    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
 
     async with httpx.AsyncClient() as client:
         response = await client.post("http://test_url")
@@ -91,22 +87,22 @@ async def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", content=b"test content 1", status_code=200
+        "http://test_url", method="GET", data=b"test content 1", status_code=200
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", content=b"test content 2", status_code=201
+        "http://test_url", method="POST", data=b"test content 2", status_code=201
     )
     httpx_mock.add_response(
-        "http://test_url", method="PUT", content=b"test content 3", status_code=202
+        "http://test_url", method="PUT", data=b"test content 3", status_code=202
     )
     httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4", status_code=303
+        "http://test_url", method="DELETE", data=b"test content 4", status_code=303
     )
     httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5", status_code=404
+        "http://test_url", method="PATCH", data=b"test content 5", status_code=404
     )
     httpx_mock.add_response(
-        "http://test_url", method="HEAD", content=b"test content 6", status_code=500
+        "http://test_url", method="HEAD", data=b"test content 6", status_code=500
     )
 
     async with httpx.AsyncClient() as client:
@@ -138,22 +134,22 @@ async def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock
 @pytest.mark.asyncio
 async def test_httpx_mock_with_many_responses_urls_str(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url?param1=test", method="GET", content=b"test content 1"
+        "http://test_url?param1=test", method="GET", data=b"test content 1"
     )
     httpx_mock.add_response(
-        "http://test_url?param2=test", method="POST", content=b"test content 2"
+        "http://test_url?param2=test", method="POST", data=b"test content 2"
     )
     httpx_mock.add_response(
-        "http://test_url?param3=test", method="PUT", content=b"test content 3"
+        "http://test_url?param3=test", method="PUT", data=b"test content 3"
     )
     httpx_mock.add_response(
-        "http://test_url?param4=test", method="DELETE", content=b"test content 4"
+        "http://test_url?param4=test", method="DELETE", data=b"test content 4"
     )
     httpx_mock.add_response(
-        "http://test_url?param5=test", method="PATCH", content=b"test content 5"
+        "http://test_url?param5=test", method="PATCH", data=b"test content 5"
     )
     httpx_mock.add_response(
-        "http://test_url?param6=test", method="HEAD", content=b"test content 6"
+        "http://test_url?param6=test", method="HEAD", data=b"test content 6"
     )
 
     async with httpx.AsyncClient() as client:
@@ -193,32 +189,32 @@ async def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMo
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param1": "test"}),
         method="GET",
-        content=b"test content 1",
+        data=b"test content 1",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param2": "test"}),
         method="POST",
-        content=b"test content 2",
+        data=b"test content 2",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param3": "test"}),
         method="PUT",
-        content=b"test content 3",
+        data=b"test content 3",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param4": "test"}),
         method="DELETE",
-        content=b"test content 4",
+        data=b"test content 4",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param5": "test"}),
         method="PATCH",
-        content=b"test content 5",
+        data=b"test content 5",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param6": "test"}),
         method="HEAD",
-        content=b"test content 6",
+        data=b"test content 6",
     )
 
     async with httpx.AsyncClient() as client:
@@ -244,7 +240,7 @@ async def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMo
 @pytest.mark.asyncio
 async def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", http_version="HTTP/2", content=b"test content 1"
+        "http://test_url", http_version="HTTP/2", data=b"test content 1"
     )
 
     async with httpx.AsyncClient() as client:
@@ -256,7 +252,7 @@ async def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", content=b"test content 1", headers={"X-Test": "Test value"}
+        "http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
     )
 
     async with httpx.AsyncClient() as client:
@@ -266,17 +262,55 @@ async def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_httpx_mock_multipart_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", data={"key1": "value1"})
+    httpx_mock.add_response(
+        "http://test_url",
+        files={"file1": "content of file 1"},
+        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
+    )
+    httpx_mock.add_response(
+        "http://test_url",
+        data={"key1": "value1"},
+        files={"file1": "content of file 1"},
+        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.text == "key1=value1"
+
+        response = await client.get("http://test_url")
+        assert (
+            response.text
+            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
+        )
+
+        response = await client.get("http://test_url")
+        assert (
+            response.text
+            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="key1"\r
+\r
+value1\r
+--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="file1"; filename="upload"\r
+Content-Type: application/octet-stream\r
+\r
+content of file 1\r
+--2256d3a36d2a61a1eba35a22bee5c74a--\r
+"""
+        )
+
+
+@pytest.mark.asyncio
 async def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
-    httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4"
-    )
-    httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5"
-    )
-    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
+    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
+    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
 
     async with httpx.AsyncClient() as client:
         await client.post("http://test_url", data=b"sent content 2")

--- a/tests/test_httpx_mock.py
+++ b/tests/test_httpx_mock.py
@@ -297,3 +297,22 @@ def test_httpx_mock_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXM
         == "test header 2"
     )
     assert not httpx_mock.get_request(httpx.URL("http://test_url"))
+
+
+def test_httpx_mock_requests_json_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        "http://test_url", json=["list content 1", "list content 2"]
+    )
+    httpx_mock.add_response(
+        "http://test_url", method="POST", json={"key 1": "value 1", "key 2": "value 2"}
+    )
+    httpx_mock.add_response("http://test_url", method="PUT", json="string value")
+
+    response = httpx.post("http://test_url")
+    assert response.json() == {"key 1": "value 1", "key 2": "value 2"}
+
+    response = httpx.get("http://test_url")
+    assert response.json() == ["list content 1", "list content 2"]
+
+    response = httpx.put("http://test_url")
+    assert response.json() == "string value"

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -6,24 +6,19 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 def test_httpx_mock_without_response(httpx_mock: HTTPXMock):
     with pytest.raises(Exception) as exception_info:
-        httpx.get("http://test_url")
+        with httpx.Client() as client:
+            client.get("http://test_url")
     assert (
         str(exception_info.value)
         == "No mock can be found for GET request on http://test_url."
     )
 
 
-@pytest.mark.xfail(
-    raises=AssertionError, reason="Unused responses should fail test case."
-)
-def test_httpx_mock_unused_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
-
-
 def test_httpx_mock_default_response(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
-    response = httpx.get("http://test_url")
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
     assert response.content == b""
     assert response.status_code == 200
     assert response.headers == httpx.Headers({})
@@ -33,25 +28,27 @@ def test_httpx_mock_default_response(httpx_mock: HTTPXMock):
 def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", content=b"test content")
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content"
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.content == b"test content"
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content"
+        response = client.get("http://test_url")
+        assert response.content == b"test content"
 
 
 def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url", content=b"test content 1")
     httpx_mock.add_response("http://test_url", content=b"test content 2")
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 1"
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.content == b"test content 1"
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 2"
+        response = client.get("http://test_url")
+        assert response.content == b"test content 2"
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 2"
+        response = client.get("http://test_url")
+        assert response.content == b"test content 2"
 
 
 def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
@@ -66,23 +63,24 @@ def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
     )
     httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
 
-    response = httpx.post("http://test_url")
-    assert response.content == b"test content 2"
+    with httpx.Client() as client:
+        response = client.post("http://test_url")
+        assert response.content == b"test content 2"
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 1"
+        response = client.get("http://test_url")
+        assert response.content == b"test content 1"
 
-    response = httpx.put("http://test_url")
-    assert response.content == b"test content 3"
+        response = client.put("http://test_url")
+        assert response.content == b"test content 3"
 
-    response = httpx.head("http://test_url")
-    assert response.content == b"test content 6"
+        response = client.head("http://test_url")
+        assert response.content == b"test content 6"
 
-    response = httpx.patch("http://test_url")
-    assert response.content == b"test content 5"
+        response = client.patch("http://test_url")
+        assert response.content == b"test content 5"
 
-    response = httpx.delete("http://test_url")
-    assert response.content == b"test content 4"
+        response = client.delete("http://test_url")
+        assert response.content == b"test content 4"
 
 
 def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
@@ -105,29 +103,30 @@ def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
         "http://test_url", method="HEAD", content=b"test content 6", status_code=500
     )
 
-    response = httpx.post("http://test_url")
-    assert response.content == b"test content 2"
-    assert response.status_code == 201
+    with httpx.Client() as client:
+        response = client.post("http://test_url")
+        assert response.content == b"test content 2"
+        assert response.status_code == 201
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 1"
-    assert response.status_code == 200
+        response = client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.status_code == 200
 
-    response = httpx.put("http://test_url")
-    assert response.content == b"test content 3"
-    assert response.status_code == 202
+        response = client.put("http://test_url")
+        assert response.content == b"test content 3"
+        assert response.status_code == 202
 
-    response = httpx.head("http://test_url")
-    assert response.content == b"test content 6"
-    assert response.status_code == 500
+        response = client.head("http://test_url")
+        assert response.content == b"test content 6"
+        assert response.status_code == 500
 
-    response = httpx.patch("http://test_url")
-    assert response.content == b"test content 5"
-    assert response.status_code == 404
+        response = client.patch("http://test_url")
+        assert response.content == b"test content 5"
+        assert response.status_code == 404
 
-    response = httpx.delete("http://test_url")
-    assert response.content == b"test content 4"
-    assert response.status_code == 303
+        response = client.delete("http://test_url")
+        assert response.content == b"test content 4"
+        assert response.status_code == 303
 
 
 def test_httpx_mock_with_many_responses_urls_str(httpx_mock: HTTPXMock):
@@ -150,23 +149,26 @@ def test_httpx_mock_with_many_responses_urls_str(httpx_mock: HTTPXMock):
         "http://test_url?param6=test", method="HEAD", content=b"test content 6"
     )
 
-    response = httpx.post(httpx.URL("http://test_url", params={"param2": "test"}))
-    assert response.content == b"test content 2"
+    with httpx.Client() as client:
+        response = client.post(httpx.URL("http://test_url", params={"param2": "test"}))
+        assert response.content == b"test content 2"
 
-    response = httpx.get(httpx.URL("http://test_url", params={"param1": "test"}))
-    assert response.content == b"test content 1"
+        response = client.get(httpx.URL("http://test_url", params={"param1": "test"}))
+        assert response.content == b"test content 1"
 
-    response = httpx.put(httpx.URL("http://test_url", params={"param3": "test"}))
-    assert response.content == b"test content 3"
+        response = client.put(httpx.URL("http://test_url", params={"param3": "test"}))
+        assert response.content == b"test content 3"
 
-    response = httpx.head(httpx.URL("http://test_url", params={"param6": "test"}))
-    assert response.content == b"test content 6"
+        response = client.head(httpx.URL("http://test_url", params={"param6": "test"}))
+        assert response.content == b"test content 6"
 
-    response = httpx.patch(httpx.URL("http://test_url", params={"param5": "test"}))
-    assert response.content == b"test content 5"
+        response = client.patch(httpx.URL("http://test_url", params={"param5": "test"}))
+        assert response.content == b"test content 5"
 
-    response = httpx.delete(httpx.URL("http://test_url", params={"param4": "test"}))
-    assert response.content == b"test content 4"
+        response = client.delete(
+            httpx.URL("http://test_url", params={"param4": "test"})
+        )
+        assert response.content == b"test content 4"
 
 
 def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
@@ -201,23 +203,24 @@ def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
         content=b"test content 6",
     )
 
-    response = httpx.post("http://test_url?param2=test")
-    assert response.content == b"test content 2"
+    with httpx.Client() as client:
+        response = client.post("http://test_url?param2=test")
+        assert response.content == b"test content 2"
 
-    response = httpx.get("http://test_url?param1=test")
-    assert response.content == b"test content 1"
+        response = client.get("http://test_url?param1=test")
+        assert response.content == b"test content 1"
 
-    response = httpx.put("http://test_url?param3=test")
-    assert response.content == b"test content 3"
+        response = client.put("http://test_url?param3=test")
+        assert response.content == b"test content 3"
 
-    response = httpx.head("http://test_url?param6=test")
-    assert response.content == b"test content 6"
+        response = client.head("http://test_url?param6=test")
+        assert response.content == b"test content 6"
 
-    response = httpx.patch("http://test_url?param5=test")
-    assert response.content == b"test content 5"
+        response = client.patch("http://test_url?param5=test")
+        assert response.content == b"test content 5"
 
-    response = httpx.delete("http://test_url?param4=test")
-    assert response.content == b"test content 4"
+        response = client.delete("http://test_url?param4=test")
+        assert response.content == b"test content 4"
 
 
 def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
@@ -225,9 +228,10 @@ def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
         "http://test_url", http_version="HTTP/2", content=b"test content 1"
     )
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 1"
-    assert response.http_version == "HTTP/2"
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.http_version == "HTTP/2"
 
 
 def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
@@ -235,9 +239,10 @@ def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
         "http://test_url", content=b"test content 1", headers={"X-Test": "Test value"}
     )
 
-    response = httpx.get("http://test_url")
-    assert response.content == b"test content 1"
-    assert response.headers == httpx.Headers({"x-test": "Test value"})
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.content == b"test content 1"
+        assert response.headers == httpx.Headers({"x-test": "Test value"})
 
 
 def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
@@ -252,12 +257,13 @@ def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
     )
     httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
 
-    httpx.post("http://test_url", data=b"sent content 2")
-    httpx.get("http://test_url", headers={"X-TEST": "test header 1"})
-    httpx.put("http://test_url", data=b"sent content 3")
-    httpx.head("http://test_url")
-    httpx.patch("http://test_url", data=b"sent content 5")
-    httpx.delete("http://test_url", headers={"X-Test": "test header 4"})
+    with httpx.Client() as client:
+        client.post("http://test_url", data=b"sent content 2")
+        client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        client.put("http://test_url", data=b"sent content 3")
+        client.head("http://test_url")
+        client.patch("http://test_url", data=b"sent content 5")
+        client.delete("http://test_url", headers={"X-Test": "test header 4"})
 
     assert (
         httpx_mock.get_request(httpx.URL("http://test_url"), "PATCH").read()
@@ -285,8 +291,9 @@ def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
 def test_httpx_mock_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
-    httpx.get("http://test_url", headers={"X-TEST": "test header 1"})
-    httpx.get("http://test_url", headers={"X-TEST": "test header 2"})
+    with httpx.Client() as client:
+        client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        client.get("http://test_url", headers={"X-TEST": "test header 2"})
 
     assert (
         httpx_mock.get_request(httpx.URL("http://test_url")).headers["x-test"]
@@ -308,11 +315,12 @@ def test_httpx_mock_requests_json_body(httpx_mock: HTTPXMock):
     )
     httpx_mock.add_response("http://test_url", method="PUT", json="string value")
 
-    response = httpx.post("http://test_url")
-    assert response.json() == {"key 1": "value 1", "key 2": "value 2"}
+    with httpx.Client() as client:
+        response = client.post("http://test_url")
+        assert response.json() == {"key 1": "value 1", "key 2": "value 2"}
 
-    response = httpx.get("http://test_url")
-    assert response.json() == ["list content 1", "list content 2"]
+        response = client.get("http://test_url")
+        assert response.json() == ["list content 1", "list content 2"]
 
-    response = httpx.put("http://test_url")
-    assert response.json() == "string value"
+        response = client.put("http://test_url")
+        assert response.json() == "string value"

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -26,7 +26,7 @@ def test_httpx_mock_default_response(httpx_mock: HTTPXMock):
 
 
 def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content=b"test content")
+    httpx_mock.add_response("http://test_url", data=b"test content")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -37,8 +37,8 @@ def test_httpx_mock_with_one_response(httpx_mock: HTTPXMock):
 
 
 def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", content=b"test content 2")
+    httpx_mock.add_response("http://test_url", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", data=b"test content 2")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -52,16 +52,12 @@ def test_httpx_mock_with_many_responses(httpx_mock: HTTPXMock):
 
 
 def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
-    httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4"
-    )
-    httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5"
-    )
-    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
+    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
+    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
 
     with httpx.Client() as client:
         response = client.post("http://test_url")
@@ -85,22 +81,22 @@ def test_httpx_mock_with_many_responses_methods(httpx_mock: HTTPXMock):
 
 def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", content=b"test content 1", status_code=200
+        "http://test_url", method="GET", data=b"test content 1", status_code=200
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", content=b"test content 2", status_code=201
+        "http://test_url", method="POST", data=b"test content 2", status_code=201
     )
     httpx_mock.add_response(
-        "http://test_url", method="PUT", content=b"test content 3", status_code=202
+        "http://test_url", method="PUT", data=b"test content 3", status_code=202
     )
     httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4", status_code=303
+        "http://test_url", method="DELETE", data=b"test content 4", status_code=303
     )
     httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5", status_code=404
+        "http://test_url", method="PATCH", data=b"test content 5", status_code=404
     )
     httpx_mock.add_response(
-        "http://test_url", method="HEAD", content=b"test content 6", status_code=500
+        "http://test_url", method="HEAD", data=b"test content 6", status_code=500
     )
 
     with httpx.Client() as client:
@@ -131,22 +127,22 @@ def test_httpx_mock_with_many_responses_status_codes(httpx_mock: HTTPXMock):
 
 def test_httpx_mock_with_many_responses_urls_str(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url?param1=test", method="GET", content=b"test content 1"
+        "http://test_url?param1=test", method="GET", data=b"test content 1"
     )
     httpx_mock.add_response(
-        "http://test_url?param2=test", method="POST", content=b"test content 2"
+        "http://test_url?param2=test", method="POST", data=b"test content 2"
     )
     httpx_mock.add_response(
-        "http://test_url?param3=test", method="PUT", content=b"test content 3"
+        "http://test_url?param3=test", method="PUT", data=b"test content 3"
     )
     httpx_mock.add_response(
-        "http://test_url?param4=test", method="DELETE", content=b"test content 4"
+        "http://test_url?param4=test", method="DELETE", data=b"test content 4"
     )
     httpx_mock.add_response(
-        "http://test_url?param5=test", method="PATCH", content=b"test content 5"
+        "http://test_url?param5=test", method="PATCH", data=b"test content 5"
     )
     httpx_mock.add_response(
-        "http://test_url?param6=test", method="HEAD", content=b"test content 6"
+        "http://test_url?param6=test", method="HEAD", data=b"test content 6"
     )
 
     with httpx.Client() as client:
@@ -175,32 +171,32 @@ def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param1": "test"}),
         method="GET",
-        content=b"test content 1",
+        data=b"test content 1",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param2": "test"}),
         method="POST",
-        content=b"test content 2",
+        data=b"test content 2",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param3": "test"}),
         method="PUT",
-        content=b"test content 3",
+        data=b"test content 3",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param4": "test"}),
         method="DELETE",
-        content=b"test content 4",
+        data=b"test content 4",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param5": "test"}),
         method="PATCH",
-        content=b"test content 5",
+        data=b"test content 5",
     )
     httpx_mock.add_response(
         httpx.URL("http://test_url", params={"param6": "test"}),
         method="HEAD",
-        content=b"test content 6",
+        data=b"test content 6",
     )
 
     with httpx.Client() as client:
@@ -225,7 +221,7 @@ def test_httpx_mock_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
 
 def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", http_version="HTTP/2", content=b"test content 1"
+        "http://test_url", http_version="HTTP/2", data=b"test content 1"
     )
 
     with httpx.Client() as client:
@@ -236,7 +232,7 @@ def test_httpx_mock_with_http_version_2(httpx_mock: HTTPXMock):
 
 def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", content=b"test content 1", headers={"X-Test": "Test value"}
+        "http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
     )
 
     with httpx.Client() as client:
@@ -245,17 +241,54 @@ def test_httpx_mock_with_headers(httpx_mock: HTTPXMock):
         assert response.headers == httpx.Headers({"x-test": "Test value"})
 
 
+def test_httpx_mock_multipart_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url", data={"key1": "value1"})
+    httpx_mock.add_response(
+        "http://test_url",
+        files={"file1": "content of file 1"},
+        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
+    )
+    httpx_mock.add_response(
+        "http://test_url",
+        data={"key1": "value1"},
+        files={"file1": "content of file 1"},
+        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
+    )
+
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.text == "key1=value1"
+
+        response = client.get("http://test_url")
+        assert (
+            response.text
+            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
+        )
+
+        response = client.get("http://test_url")
+        assert (
+            response.text
+            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="key1"\r
+\r
+value1\r
+--2256d3a36d2a61a1eba35a22bee5c74a\r
+Content-Disposition: form-data; name="file1"; filename="upload"\r
+Content-Type: application/octet-stream\r
+\r
+content of file 1\r
+--2256d3a36d2a61a1eba35a22bee5c74a--\r
+"""
+        )
+
+
 def test_httpx_mock_requests_retrieval(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", content=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", content=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", content=b"test content 3")
-    httpx_mock.add_response(
-        "http://test_url", method="DELETE", content=b"test content 4"
-    )
-    httpx_mock.add_response(
-        "http://test_url", method="PATCH", content=b"test content 5"
-    )
-    httpx_mock.add_response("http://test_url", method="HEAD", content=b"test content 6")
+    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
+    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
+    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
+    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
 
     with httpx.Client() as client:
         client.post("http://test_url", data=b"sent content 2")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -463,6 +463,28 @@ def test_callback_returning_response(httpx_mock: HTTPXMock):
         assert response.json() == {"url": "http://test_url"}
 
 
+def test_callback_executed_twice(httpx_mock: HTTPXMock):
+    def custom_response(
+        request: httpx.Request, timeout: Optional[httpx.Timeout], *args, **kwargs
+    ) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            http_version="HTTP/1.1",
+            headers=[],
+            stream=content_streams.JSONStream(["content"]),
+            request=request,
+        )
+
+    httpx_mock.add_callback(custom_response, "http://test_url")
+
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.json() == ["content"]
+
+        response = client.get("http://test_url")
+        assert response.json() == ["content"]
+
+
 @pytest.mark.xfail(
     raises=AssertionError,
     reason="Single request cannot be returned if there is more than one matching.",

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 import pytest
 import httpx
+from httpx import content_streams
 
 from pytest_httpx import httpx_mock, HTTPXMock
 
@@ -357,3 +360,35 @@ def test_httpx_mock_requests_json_body(httpx_mock: HTTPXMock):
 
         response = client.put("http://test_url")
         assert response.json() == "string value"
+
+
+def test_callback_raising_exception(httpx_mock: HTTPXMock):
+    def raise_timeout(
+        request: httpx.Request, timeout: Optional[httpx.Timeout]
+    ) -> httpx.Response:
+        raise httpx.exceptions.TimeoutException()
+
+    httpx_mock.add_callback(raise_timeout, "http://test_url")
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.exceptions.TimeoutException):
+            client.get("http://test_url")
+
+
+def test_callback_returning_response(httpx_mock: HTTPXMock):
+    def custom_response(
+        request: httpx.Request, timeout: Optional[httpx.Timeout]
+    ) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            http_version="HTTP/1.1",
+            headers=[],
+            stream=content_streams.JSONStream({"url": str(request.url)}),
+            request=request,
+        )
+
+    httpx_mock.add_callback(custom_response, "http://test_url")
+
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.json() == {"url": "http://test_url"}

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -8,3 +8,10 @@ from pytest_httpx import httpx_mock, HTTPXMock
 )
 def test_httpx_mock_unused_response(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
+
+
+@pytest.mark.xfail(
+    raises=AssertionError, reason="Unused callbacks should fail test case."
+)
+def test_httpx_mock_unused_callback(httpx_mock: HTTPXMock):
+    httpx_mock.add_callback(lambda r, t: None, "http://test_url")

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+@pytest.mark.xfail(
+    raises=AssertionError, reason="Unused responses should fail test case."
+)
+def test_httpx_mock_unused_response(httpx_mock: HTTPXMock):
+    httpx_mock.add_response("http://test_url")


### PR DESCRIPTION
### Added
- Allow to provide JSON response as python values.
- Mock async httpx requests as well.
- Allow to provide files and boundary for multipart response.
- Allow to provide data as a dictionary for multipart response.
- Allow to provide callbacks that are executed upon reception of a request.
- Handle the fact that parameters may be introduced in httpx *Dispatcher.send method.
- Allow to retrieve all matching requests with HTTPXMock.get_requests
### Changed
- method can now be provided even if not entirely upper cased.
- content parameter renamed into data.
- HTTPXMock.get_request now fails if more than one request match. Use HTTPXMock.get_request instead.
- HTTPXMock.requests is now private, use HTTPXMock.get_requests instead.
- HTTPXMock.responses is now private, it should not be accessed anyway.
- url can now be a re.Pattern instance.
