### PR TITLE
Release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.4] - 2020-02-07
 ### Changed
 - url is not a mandatory parameter for response registration anymore.
 - url is not a mandatory parameter for callback registration anymore.
@@ -40,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.3...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/Colin-b/pytest_httpx/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - method does not have a default value for response registration anymore.
 - method does not have a default value for callback registration anymore.
 - method does not have a default value for request retrieval anymore.
+- url and methods are not positional arguments anymore.
 
 ## [0.0.3] - 2020-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- url is not a mandatory parameter for response registration anymore.
+- url is not a mandatory parameter for callback registration anymore.
+- url is not a mandatory parameter for request retrieval anymore.
+- method does not have a default value for response registration anymore.
+- method does not have a default value for callback registration anymore.
+- method does not have a default value for request retrieval anymore.
 
 ## [0.0.3] - 2020-02-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ You can add criteria so that response will be sent only in case of a more specif
 
 Matching is performed on the full URL, query parameters included.
 
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_url(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url")
+
+    with httpx.Client() as client:
+        response1 = client.delete("http://test_url")
+        response2 = client.get("http://test_url")
+```
+
 #### Matching on HTTP method
 
 Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) to reply to

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_json(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", json=[{"key1": "value1", "key2": "value2"}])
+    httpx_mock.add_response(json=[{"key1": "value1", "key2": "value2"}])
 
     with httpx.Client() as client:
         assert client.get("http://test_url").json() == [{"key1": "value1", "key2": "value2"}]
@@ -101,14 +101,14 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_str_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data="This is my UTF-8 content")
+    httpx_mock.add_response(data="This is my UTF-8 content")
 
     with httpx.Client() as client:
         assert client.get("http://test_url").text == "This is my UTF-8 content"
 
 
 def test_bytes_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data=b"This is my bytes content")
+    httpx_mock.add_response(data=b"This is my bytes content")
 
     with httpx.Client() as client:
         assert client.get("http://test_url").content == b"This is my bytes content"
@@ -127,7 +127,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data={"key1": "value1"}, files={"file1": "content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
+    httpx_mock.add_response(data={"key1": "value1"}, files={"file1": "content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
 
     with httpx.Client() as client:
         assert client.get("http://test_url").text == '''--2256d3a36d2a61a1eba35a22bee5c74a\r
@@ -154,35 +154,35 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_post(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="POST")
+    httpx_mock.add_response(method="POST")
 
     with httpx.Client() as client:
         response = client.post("http://test_url")
 
 
 def test_put(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="PUT")
+    httpx_mock.add_response(method="PUT")
 
     with httpx.Client() as client:
         response = client.put("http://test_url")
 
 
 def test_delete(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="DELETE")
+    httpx_mock.add_response(method="DELETE")
 
     with httpx.Client() as client:
         response = client.delete("http://test_url")
 
 
 def test_patch(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="PATCH")
+    httpx_mock.add_response(method="PATCH")
 
     with httpx.Client() as client:
         response = client.patch("http://test_url")
 
 
 def test_head(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="HEAD")
+    httpx_mock.add_response(method="HEAD")
 
     with httpx.Client() as client:
         response = client.head("http://test_url")
@@ -199,7 +199,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_status_code(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", status_code=404)
+    httpx_mock.add_response(status_code=404)
 
     with httpx.Client() as client:
         assert client.get("http://test_url").status_code == 404
@@ -216,7 +216,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_headers(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", headers={"X-Header1": "Test value"})
+    httpx_mock.add_response(headers={"X-Header1": "Test value"})
 
     with httpx.Client() as client:
         assert client.get("http://test_url").headers["x-header1"] == "Test value"
@@ -233,7 +233,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_http_version(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", http_version="HTTP/2.0")
+    httpx_mock.add_response(http_version="HTTP/2.0")
 
     with httpx.Client() as client:
         assert client.get("http://test_url").http_version == "HTTP/2.0"
@@ -270,7 +270,7 @@ def test_dynamic_response(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, "http://test_url")
+    httpx_mock.add_callback(custom_response)
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -294,7 +294,7 @@ def test_exception_raising(httpx_mock: HTTPXMock):
     def raise_timeout(*args, **kwargs) -> httpx.Response:
         raise httpx.exceptions.TimeoutException()
 
-    httpx_mock.add_callback(raise_timeout, "http://test_url")
+    httpx_mock.add_callback(raise_timeout)
     
     with httpx.Client() as client:
         with pytest.raises(httpx.exceptions.TimeoutException):
@@ -330,22 +330,22 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_many_requests(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     with httpx.Client() as client:
         response1 = client.get("http://test_url")
         response2 = client.get("http://test_url")
 
-    requests = httpx_mock.get_requests("http://test_url")
+    requests = httpx_mock.get_requests()
 
 
 def test_single_request(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
 
-    request = httpx_mock.get_request("http://test_url")
+    request = httpx_mock.get_request()
 ```
 
 ### How requests are selected

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
 
 ## Add responses
 
-You can register responses for both sync and async `httpx` requests.
+You can register responses for both sync and async [`HTTPX`](https://www.python-httpx.org) requests.
 
 ```python
 import pytest
@@ -255,14 +255,14 @@ def test_http_version(httpx_mock: HTTPXMock):
 You can perform custom manipulation upon request reception by registering callbacks.
 
 Callback should expect at least two parameters:
- * request: The received request.
- * timeout: The timeout linked to the request.
+ * request: The received [`httpx.Request`](https://www.python-httpx.org/api/#request).
+ * timeout: The [`httpx.Timeout`](https://www.python-httpx.org/advanced/#timeout-configuration) linked to the request.
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
 
 ### Dynamic responses
 
-Callback should return a httpx.Response instance.
+Callback should return a [`httpx.Response`](https://www.python-httpx.org/api/#response) instance.
 
 ```python
 import httpx
@@ -290,9 +290,9 @@ def test_dynamic_response(httpx_mock: HTTPXMock):
 
 ### Raising exceptions
 
-You can simulate httpx exception throwing by raising an exception in your callback.
+You can simulate HTTPX exception throwing by raising an exception in your callback.
 
-This can be useful if you want to assert that your code handles httpx exceptions properly.
+This can be useful if you want to assert that your code handles HTTPX exceptions properly.
 
 ```python
 import httpx

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Use `pytest_httpx.httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fix
   - [JSON body](#add-json-response)
   - [Custom body](#reply-with-custom-body)
   - [Multipart body (files, ...)](#add-multipart-response)
-  - [HTTP method](#add-non-get-response)
   - [HTTP status code](#add-non-200-response)
   - [HTTP headers](#reply-with-custom-headers)
   - [HTTP/2.0](#add-http/2.0-response)
@@ -70,9 +69,52 @@ Matching is performed on the full URL, query parameters included.
 
 #### Matching on HTTP method
 
+Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) to reply to
+
 `method` parameter must be a string. It will be upper cased so it can be provided lower cased.
 
 Matching is performed on equality.
+
+```python
+import httpx
+from pytest_httpx import httpx_mock, HTTPXMock
+
+
+def test_post(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="POST")
+
+    with httpx.Client() as client:
+        response = client.post("http://test_url")
+
+
+def test_put(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="PUT")
+
+    with httpx.Client() as client:
+        response = client.put("http://test_url")
+
+
+def test_delete(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="DELETE")
+
+    with httpx.Client() as client:
+        response = client.delete("http://test_url")
+
+
+def test_patch(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="PATCH")
+
+    with httpx.Client() as client:
+        response = client.patch("http://test_url")
+
+
+def test_head(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="HEAD")
+
+    with httpx.Client() as client:
+        response = client.head("http://test_url")
+    
+```
 
 ### Add JSON response
 
@@ -141,51 +183,6 @@ Content-Type: application/octet-stream\r
 content of file 1\r
 --2256d3a36d2a61a1eba35a22bee5c74a--\r
 '''
-    
-```
-
-### Add non GET response
-
-Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) to reply to on provided URL.
-
-```python
-import httpx
-from pytest_httpx import httpx_mock, HTTPXMock
-
-
-def test_post(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(method="POST")
-
-    with httpx.Client() as client:
-        response = client.post("http://test_url")
-
-
-def test_put(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(method="PUT")
-
-    with httpx.Client() as client:
-        response = client.put("http://test_url")
-
-
-def test_delete(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(method="DELETE")
-
-    with httpx.Client() as client:
-        response = client.delete("http://test_url")
-
-
-def test_patch(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(method="PATCH")
-
-    with httpx.Client() as client:
-        response = client.patch("http://test_url")
-
-
-def test_head(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(method="HEAD")
-
-    with httpx.Client() as client:
-        response = client.head("http://test_url")
     
 ```
 
@@ -318,6 +315,8 @@ Matching is performed on the full URL, query parameters included.
 
 #### Matching on HTTP method
 
+Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) executing the callback.
+
 `method` parameter must be a string. It will be upper cased so it can be provided lower cased.
 
 Matching is performed on equality.
@@ -359,6 +358,8 @@ You can add criteria so that requests will be returned only in case of a more sp
 Matching is performed on the full URL, query parameters included.
 
 #### Matching on HTTP method
+
+Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) of the requests to retrieve.
 
 `method` parameter must be a string. It will be upper cased so it can be provided lower cased.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can add criteria so that response will be sent only in case of a more specif
 
 #### Matching on URL
 
-`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
+`url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
 
 Matching is performed on the full URL, query parameters included.
 
@@ -322,7 +322,7 @@ You can add criteria so that callback will be sent only in case of a more specif
 
 #### Matching on URL
 
-`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
+`url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
 
 Matching is performed on the full URL, query parameters included.
 
@@ -366,7 +366,7 @@ You can add criteria so that requests will be returned only in case of a more sp
 
 #### Matching on URL
 
-`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
+`url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
 
 Matching is performed on the full URL, query parameters included.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-44 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-64 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -36,7 +36,7 @@ from pytest_httpx import httpx_mock, HTTPXMock
 
 
 def test_something(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -44,7 +44,7 @@ def test_something(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_something_async(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -52,21 +52,27 @@ async def test_something_async(httpx_mock: HTTPXMock):
 
 If all responses are not sent back during test execution, the test case will fail at teardown.
 
-Default response is a 200 (OK) without any body for a GET request on the provided URL using HTTP/1.1 protocol version.
+Default response is a HTTP/1.1 200 (OK) without any body.
 
 ### How response is selected
 
-Default matching is performed on the full URL, query parameters included and the HTTP method.
+In case more than one response match request, the first one not yet sent (according to the registration order) will be sent.
 
-Registration order is kept while checking what response to send.
+In case all matching responses have been sent, the last one (according to the registration order) will be sent.
 
-In case more than one response match request, the first one not yet sent will be sent.
+You can add criteria so that response will be sent only in case of a more specific matching.
 
-In case all matching responses have been sent, the last registered one will be sent.
+#### Matching on URL
 
-#### Providing URL
+`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
 
-URL can either be a string, a python re.Pattern instance or a httpx.URL instance.
+Matching is performed on the full URL, query parameters included.
+
+#### Matching on HTTP method
+
+`method` parameter must be a string. It will be upper cased so it can be provided lower cased.
+
+Matching is performed on equality.
 
 ### Add JSON response
 
@@ -244,8 +250,6 @@ Callback should expect at least two parameters:
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
 
-Default callback is for a GET request on the provided URL.
-
 ### Dynamic responses
 
 Callback should return a httpx.Response instance.
@@ -300,17 +304,23 @@ def test_exception_raising(httpx_mock: HTTPXMock):
 
 ### How callback is selected
 
-Default matching is performed on the full URL, query parameters included and the HTTP method.
+In case more than one callback match request, the first one not yet executed (according to the registration order) will be executed.
 
-Registration order is kept while checking what callback to execute.
+In case all matching callbacks have been executed, the last one (according to the registration order) will be executed.
 
-In case more than one callback match request, the first one not yet executed will be sent.
+You can add criteria so that callback will be sent only in case of a more specific matching.
 
-In case all matching callbacks have been sent, the last registered one will be sent.
+#### Matching on URL
 
-#### Providing URL
+`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
 
-URL can either be a string, a python re.Pattern instance or a httpx.URL instance.
+Matching is performed on the full URL, query parameters included.
+
+#### Matching on HTTP method
+
+`method` parameter must be a string. It will be upper cased so it can be provided lower cased.
+
+Matching is performed on equality.
 
 ## Check sent requests
 
@@ -340,10 +350,16 @@ def test_single_request(httpx_mock: HTTPXMock):
 
 ### How requests are selected
 
-Default matching is performed on the full URL, query parameters included and the HTTP method.
+You can add criteria so that requests will be returned only in case of a more specific matching.
 
-Request original order is kept while appending to the list.
+#### Matching on URL
 
-#### Providing URL
+`url` parameter can either be a string, a python re.Pattern instance or a httpx.URL instance.
 
-URL can either be a string, a python re.Pattern instance or a httpx.URL instance.
+Matching is performed on the full URL, query parameters included.
+
+#### Matching on HTTP method
+
+`method` parameter must be a string. It will be upper cased so it can be provided lower cased.
+
+Matching is performed on equality.

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -27,8 +27,10 @@ class _RequestMatcher:
             self.url, re._pattern_type if hasattr(re, "_pattern_type") else re.Pattern
         ):
             return self.url.match(str(request.url)) is not None
+
         if isinstance(self.url, str):
             return URL(self.url) == request.url
+
         return self.url == request.url
 
     def _method_match(self, request: Request) -> bool:

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -80,12 +80,7 @@ class HTTPXMock:
         )
         self._responses.append((_RequestMatcher(**matchers), response))
 
-    def add_callback(
-        self,
-        callback: Callable,
-        url: Union[str, Pattern, URL] = None,
-        method: str = None,
-    ):
+    def add_callback(self, callback: Callable, **matchers):
         """
         Mock the action that will take place if a request match.
 
@@ -97,7 +92,7 @@ class HTTPXMock:
         :param url: Full URL identifying the request(s) to match. Can be a str, a re.Pattern instance or a httpx.URL instance.
         :param method: HTTP method identifying the request(s) to match.
         """
-        self._callbacks.append((_RequestMatcher(url, method), callback))
+        self._callbacks.append((_RequestMatcher(**matchers), callback))
 
     def _handle_request(
         self, request: Request, timeout: Optional[Timeout], *args, **kwargs
@@ -164,21 +159,17 @@ class HTTPXMock:
 
     # TODO Allow to assert requests content / files / whatever
 
-    def get_requests(
-        self, url: Union[str, Pattern, URL] = None, method: str = None
-    ) -> List[Request]:
+    def get_requests(self, **matchers) -> List[Request]:
         """
         Return all requests sent that match (empty list if no requests were matched).
 
         :param url: Full URL identifying the requests to retrieve. Can be a str, a re.Pattern instance or a httpx.URL instance.
         :param method: HTTP method identifying the requests to retrieve. Must be a upper cased string value.
         """
-        matcher = _RequestMatcher(url, method)
+        matcher = _RequestMatcher(**matchers)
         return [request for request in self._requests if matcher.match(request)]
 
-    def get_request(
-        self, url: Union[str, Pattern, URL] = None, method: str = None
-    ) -> Optional[Request]:
+    def get_request(self, **matchers) -> Optional[Request]:
         """
         Return the single request that match (or None).
 
@@ -186,7 +177,7 @@ class HTTPXMock:
         :param method: HTTP method identifying the request to retrieve. Must be a upper cased string value.
         :raises AssertionError: in case more than one request match.
         """
-        requests = self.get_requests(url, method)
+        requests = self.get_requests(**matchers)
         assert (
             len(requests) <= 1
         ), f"More than one request ({len(requests)}) matched, use get_requests instead."

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -158,6 +158,8 @@ class HTTPXMock:
         matcher.nb_calls += 1
         return callback
 
+    # TODO Allow to assert requests content / files / whatever
+
     def get_requests(
         self, url: Union[str, Pattern, URL] = None, method: str = None
     ) -> List[Request]:

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -3,7 +3,7 @@ from typing import List, Union, Optional, Callable, Tuple, Pattern, Any
 
 import httpx
 import pytest
-from httpx import Request, Response, Timeout, URL, content_streams
+from httpx import Request, Response, URL, content_streams
 from httpx.dispatch.base import SyncDispatcher, AsyncDispatcher
 
 
@@ -84,7 +84,7 @@ class HTTPXMock:
         """
         Mock the action that will take place if a request match.
 
-        :param callback: The callable that will be called upon reception of the request.
+        :param callback: The callable that will be called upon reception of the matched request.
         It must expect at least 2 parameters:
          * request: The received request.
          * timeout: The timeout linked to the request.
@@ -94,9 +94,7 @@ class HTTPXMock:
         """
         self._callbacks.append((_RequestMatcher(**matchers), callback))
 
-    def _handle_request(
-        self, request: Request, timeout: Optional[Timeout], *args, **kwargs
-    ) -> Response:
+    def _handle_request(self, request: Request, *args, **kwargs) -> Response:
         self._requests.append(request)
 
         response = self._get_response(request)
@@ -105,7 +103,7 @@ class HTTPXMock:
 
         callback = self._get_callback(request)
         if callback:
-            return callback(request=request, timeout=timeout, *args, **kwargs)
+            return callback(request=request, *args, **kwargs)
 
         raise Exception(
             f"No mock can be found for {request.method} request on {request.url}."

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -57,7 +57,7 @@ async def test_method_matching(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_with_one_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data=b"test content")
+    httpx_mock.add_response(url="http://test_url", data=b"test content")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -69,8 +69,8 @@ async def test_with_one_response(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_with_many_responses(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", data=b"test content 2")
+    httpx_mock.add_response(url="http://test_url", data=b"test content 1")
+    httpx_mock.add_response(url="http://test_url", data=b"test content 2")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -85,12 +85,20 @@ async def test_with_many_responses(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_with_many_responses_methods(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
-    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
-    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
-    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
+    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(
+        url="http://test_url", method="POST", data=b"test content 2"
+    )
+    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(
+        url="http://test_url", method="DELETE", data=b"test content 4"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="PATCH", data=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", data=b"test content 6"
+    )
 
     async with httpx.AsyncClient() as client:
         response = await client.post("http://test_url")
@@ -115,22 +123,22 @@ async def test_with_many_responses_methods(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", data=b"test content 1", status_code=200
+        url="http://test_url", method="GET", data=b"test content 1", status_code=200
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", data=b"test content 2", status_code=201
+        url="http://test_url", method="POST", data=b"test content 2", status_code=201
     )
     httpx_mock.add_response(
-        "http://test_url", method="PUT", data=b"test content 3", status_code=202
+        url="http://test_url", method="PUT", data=b"test content 3", status_code=202
     )
     httpx_mock.add_response(
-        "http://test_url", method="DELETE", data=b"test content 4", status_code=303
+        url="http://test_url", method="DELETE", data=b"test content 4", status_code=303
     )
     httpx_mock.add_response(
-        "http://test_url", method="PATCH", data=b"test content 5", status_code=404
+        url="http://test_url", method="PATCH", data=b"test content 5", status_code=404
     )
     httpx_mock.add_response(
-        "http://test_url", method="HEAD", data=b"test content 6", status_code=500
+        url="http://test_url", method="HEAD", data=b"test content 6", status_code=500
     )
 
     async with httpx.AsyncClient() as client:
@@ -162,22 +170,22 @@ async def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url?param1=test", method="GET", data=b"test content 1"
+        url="http://test_url?param1=test", method="GET", data=b"test content 1"
     )
     httpx_mock.add_response(
-        "http://test_url?param2=test", method="POST", data=b"test content 2"
+        url="http://test_url?param2=test", method="POST", data=b"test content 2"
     )
     httpx_mock.add_response(
-        "http://test_url?param3=test", method="PUT", data=b"test content 3"
+        url="http://test_url?param3=test", method="PUT", data=b"test content 3"
     )
     httpx_mock.add_response(
-        "http://test_url?param4=test", method="DELETE", data=b"test content 4"
+        url="http://test_url?param4=test", method="DELETE", data=b"test content 4"
     )
     httpx_mock.add_response(
-        "http://test_url?param5=test", method="PATCH", data=b"test content 5"
+        url="http://test_url?param5=test", method="PATCH", data=b"test content 5"
     )
     httpx_mock.add_response(
-        "http://test_url?param6=test", method="HEAD", data=b"test content 6"
+        url="http://test_url?param6=test", method="HEAD", data=b"test content 6"
     )
 
     async with httpx.AsyncClient() as client:
@@ -214,8 +222,8 @@ async def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_response_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(re.compile(".*test.*"))
-    httpx_mock.add_response("http://unmatched", data=b"test content")
+    httpx_mock.add_response(url=re.compile(".*test.*"))
+    httpx_mock.add_response(url="http://unmatched", data=b"test content")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://unmatched")
@@ -227,28 +235,28 @@ async def test_response_with_pattern_in_url(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_request_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
-    httpx_mock.add_response("http://unmatched")
+    httpx_mock.add_response(url="http://test_url")
+    httpx_mock.add_response(url="http://unmatched")
 
     async with httpx.AsyncClient() as client:
         await client.get("http://unmatched")
         await client.get("http://test_url", headers={"X-Test": "1"})
 
-    assert httpx_mock.get_request(re.compile(".*test.*")).headers["x-test"] == "1"
+    assert httpx_mock.get_request(url=re.compile(".*test.*")).headers["x-test"] == "1"
 
 
 @pytest.mark.asyncio
 async def test_requests_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
-    httpx_mock.add_response("http://tests_url")
-    httpx_mock.add_response("http://unmatched")
+    httpx_mock.add_response(url="http://test_url")
+    httpx_mock.add_response(url="http://tests_url")
+    httpx_mock.add_response(url="http://unmatched")
 
     async with httpx.AsyncClient() as client:
         await client.get("http://tests_url", headers={"X-Test": "1"})
         await client.get("http://unmatched", headers={"X-Test": "2"})
         await client.get("http://test_url")
 
-    requests = httpx_mock.get_requests(re.compile(".*test.*"))
+    requests = httpx_mock.get_requests(url=re.compile(".*test.*"))
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "1"
     assert "x-test" not in requests[1].headers
@@ -278,8 +286,8 @@ async def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, re.compile(".*test.*"))
-    httpx_mock.add_callback(custom_response2, "http://unmatched")
+    httpx_mock.add_callback(custom_response, url=re.compile(".*test.*"))
+    httpx_mock.add_callback(custom_response2, url="http://unmatched")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://unmatched")
@@ -292,32 +300,32 @@ async def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param1": "test"}),
+        url=httpx.URL("http://test_url", params={"param1": "test"}),
         method="GET",
         data=b"test content 1",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param2": "test"}),
+        url=httpx.URL("http://test_url", params={"param2": "test"}),
         method="POST",
         data=b"test content 2",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param3": "test"}),
+        url=httpx.URL("http://test_url", params={"param3": "test"}),
         method="PUT",
         data=b"test content 3",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param4": "test"}),
+        url=httpx.URL("http://test_url", params={"param4": "test"}),
         method="DELETE",
         data=b"test content 4",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param5": "test"}),
+        url=httpx.URL("http://test_url", params={"param5": "test"}),
         method="PATCH",
         data=b"test content 5",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param6": "test"}),
+        url=httpx.URL("http://test_url", params={"param6": "test"}),
         method="HEAD",
         data=b"test content 6",
     )
@@ -345,7 +353,7 @@ async def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_with_http_version_2(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", http_version="HTTP/2", data=b"test content 1"
+        url="http://test_url", http_version="HTTP/2", data=b"test content 1"
     )
 
     async with httpx.AsyncClient() as client:
@@ -357,7 +365,7 @@ async def test_with_http_version_2(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_with_headers(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
+        url="http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
     )
 
     async with httpx.AsyncClient() as client:
@@ -368,14 +376,14 @@ async def test_with_headers(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data={"key1": "value1"})
+    httpx_mock.add_response(url="http://test_url", data={"key1": "value1"})
     httpx_mock.add_response(
-        "http://test_url",
+        url="http://test_url",
         files={"file1": "content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
     httpx_mock.add_response(
-        "http://test_url",
+        url="http://test_url",
         data={"key1": "value1"},
         files={"file1": "content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
@@ -410,12 +418,20 @@ content of file 1\r
 
 @pytest.mark.asyncio
 async def test_requests_retrieval(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
-    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
-    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
-    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
+    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(
+        url="http://test_url", method="POST", data=b"test content 2"
+    )
+    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(
+        url="http://test_url", method="DELETE", data=b"test content 4"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="PATCH", data=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", data=b"test content 6"
+    )
 
     async with httpx.AsyncClient() as client:
         await client.post("http://test_url", data=b"sent content 2")
@@ -426,37 +442,44 @@ async def test_requests_retrieval(httpx_mock: HTTPXMock):
         await client.delete("http://test_url", headers={"X-Test": "test header 4"})
 
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "PATCH").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PATCH").read()
         == b"sent content 5"
     )
-    assert httpx_mock.get_request(httpx.URL("http://test_url"), "HEAD").read() == b""
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "PUT").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="HEAD").read()
+        == b""
+    )
+    assert (
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PUT").read()
         == b"sent content 3"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "GET").headers["x-test"]
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="GET").headers[
+            "x-test"
+        ]
         == "test header 1"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "POST").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="POST").read()
         == b"sent content 2"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "DELETE").headers["x-test"]
+        httpx_mock.get_request(
+            url=httpx.URL("http://test_url"), method="DELETE"
+        ).headers["x-test"]
         == "test header 4"
     )
 
 
 @pytest.mark.asyncio
 async def test_requests_retrieval_on_same_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response(url="http://test_url")
 
     async with httpx.AsyncClient() as client:
         await client.get("http://test_url", headers={"X-TEST": "test header 1"})
         await client.get("http://test_url", headers={"X-TEST": "test header 2"})
 
-    requests = httpx_mock.get_requests(httpx.URL("http://test_url"))
+    requests = httpx_mock.get_requests(url=httpx.URL("http://test_url"))
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "test header 1"
     assert requests[1].headers["x-test"] == "test header 2"
@@ -510,7 +533,7 @@ async def test_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
         await client.post("http://test_url", headers={"X-TEST": "test header 3"})
         await client.get("http://test_url2", headers={"X-TEST": "test header 4"})
 
-    requests = httpx_mock.get_requests(httpx.URL("http://test_url"), "GET")
+    requests = httpx_mock.get_requests(url=httpx.URL("http://test_url"), method="GET")
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "test header 1"
     assert requests[1].headers["x-test"] == "test header 2"
@@ -544,12 +567,14 @@ async def test_default_request_retrieval(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_requests_json_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", json=["list content 1", "list content 2"]
+        url="http://test_url", method="GET", json=["list content 1", "list content 2"]
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", json={"key 1": "value 1", "key 2": "value 2"}
+        url="http://test_url",
+        method="POST",
+        json={"key 1": "value 1", "key 2": "value 2"},
     )
-    httpx_mock.add_response("http://test_url", method="PUT", json="string value")
+    httpx_mock.add_response(url="http://test_url", method="PUT", json="string value")
 
     async with httpx.AsyncClient() as client:
         response = await client.post("http://test_url")
@@ -569,7 +594,7 @@ async def test_callback_raising_exception(httpx_mock: HTTPXMock):
     ) -> httpx.Response:
         raise httpx.exceptions.TimeoutException()
 
-    httpx_mock.add_callback(raise_timeout, "http://test_url")
+    httpx_mock.add_callback(raise_timeout, url="http://test_url")
 
     async with httpx.AsyncClient() as client:
         with pytest.raises(httpx.exceptions.TimeoutException):
@@ -589,7 +614,7 @@ async def test_callback_returning_response(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, "http://test_url")
+    httpx_mock.add_callback(custom_response, url="http://test_url")
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -654,4 +679,4 @@ async def test_request_retrieval_with_more_than_one(httpx_mock: HTTPXMock):
         await client.get("http://test_url", headers={"X-TEST": "test header 1"})
         await client.get("http://test_url", headers={"X-TEST": "test header 2"})
 
-    httpx_mock.get_request(httpx.URL("http://test_url"))
+    httpx_mock.get_request(url=httpx.URL("http://test_url"))

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -21,7 +21,7 @@ async def test_without_response(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_default_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
@@ -29,6 +29,30 @@ async def test_default_response(httpx_mock: HTTPXMock):
     assert response.status_code == 200
     assert response.headers == httpx.Headers({})
     assert response.http_version == "HTTP/1.1"
+
+
+@pytest.mark.asyncio
+async def test_url_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b""
+
+        response = await client.post("http://test_url")
+        assert response.content == b""
+
+
+@pytest.mark.asyncio
+async def test_method_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="get")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b""
+
+        response = await client.get("http://test_url2")
+        assert response.content == b""
 
 
 @pytest.mark.asyncio
@@ -411,7 +435,7 @@ async def test_requests_retrieval(httpx_mock: HTTPXMock):
         == b"sent content 3"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url")).headers["x-test"]
+        httpx_mock.get_request(httpx.URL("http://test_url"), "GET").headers["x-test"]
         == "test header 1"
     )
     assert (
@@ -425,7 +449,7 @@ async def test_requests_retrieval(httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
-async def test_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
+async def test_requests_retrieval_on_same_url(httpx_mock: HTTPXMock):
     httpx_mock.add_response("http://test_url")
 
     async with httpx.AsyncClient() as client:
@@ -439,9 +463,88 @@ async def test_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_request_retrieval_on_same_url(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.get("http://test_url2", headers={"X-TEST": "test header 2"})
+
+    request = httpx_mock.get_request(url=httpx.URL("http://test_url"))
+    assert request.headers["x-test"] == "test header 1"
+
+
+@pytest.mark.asyncio
+async def test_requests_retrieval_on_same_method(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.get("http://test_url2", headers={"X-TEST": "test header 2"})
+
+    requests = httpx_mock.get_requests(method="GET")
+    assert len(requests) == 2
+    assert requests[0].headers["x-test"] == "test header 1"
+    assert requests[1].headers["x-test"] == "test header 2"
+
+
+@pytest.mark.asyncio
+async def test_request_retrieval_on_same_method(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.post("http://test_url", headers={"X-TEST": "test header 2"})
+
+    request = httpx_mock.get_request(method="GET")
+    assert request.headers["x-test"] == "test header 1"
+
+
+@pytest.mark.asyncio
+async def test_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.get("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.get("http://test_url", headers={"X-TEST": "test header 2"})
+        await client.post("http://test_url", headers={"X-TEST": "test header 3"})
+        await client.get("http://test_url2", headers={"X-TEST": "test header 4"})
+
+    requests = httpx_mock.get_requests(httpx.URL("http://test_url"), "GET")
+    assert len(requests) == 2
+    assert requests[0].headers["x-test"] == "test header 1"
+    assert requests[1].headers["x-test"] == "test header 2"
+
+
+@pytest.mark.asyncio
+async def test_default_requests_retrieval(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.post("http://test_url", headers={"X-TEST": "test header 1"})
+        await client.get("http://test_url2", headers={"X-TEST": "test header 2"})
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    assert requests[0].headers["x-test"] == "test header 1"
+    assert requests[1].headers["x-test"] == "test header 2"
+
+
+@pytest.mark.asyncio
+async def test_default_request_retrieval(httpx_mock: HTTPXMock):
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.post("http://test_url", headers={"X-TEST": "test header 1"})
+
+    request = httpx_mock.get_request()
+    assert request.headers["x-test"] == "test header 1"
+
+
+@pytest.mark.asyncio
 async def test_requests_json_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", json=["list content 1", "list content 2"]
+        "http://test_url", method="GET", json=["list content 1", "list content 2"]
     )
     httpx_mock.add_response(
         "http://test_url", method="POST", json={"key 1": "value 1", "key 2": "value 2"}
@@ -506,13 +609,36 @@ async def test_callback_executed_twice(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, "http://test_url")
+    httpx_mock.add_callback(custom_response)
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
         assert response.json() == ["content"]
 
+        response = await client.post("http://test_url")
+        assert response.json() == ["content"]
+
+
+@pytest.mark.asyncio
+async def test_callback_matching_method(httpx_mock: HTTPXMock):
+    def custom_response(
+        request: httpx.Request, timeout: Optional[httpx.Timeout], *args, **kwargs
+    ) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            http_version="HTTP/1.1",
+            headers=[],
+            stream=content_streams.JSONStream(["content"]),
+            request=request,
+        )
+
+    httpx_mock.add_callback(custom_response, method="GET")
+
+    async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
+        assert response.json() == ["content"]
+
+        response = await client.get("http://test_url2")
         assert response.json() == ["content"]
 
 
@@ -522,7 +648,7 @@ async def test_callback_executed_twice(httpx_mock: HTTPXMock):
 )
 @pytest.mark.asyncio
 async def test_request_retrieval_with_more_than_one(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
     async with httpx.AsyncClient() as client:
         await client.get("http://test_url", headers={"X-TEST": "test header 1"})

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -52,7 +52,7 @@ def test_method_matching(httpx_mock: HTTPXMock):
 
 
 def test_with_one_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data=b"test content")
+    httpx_mock.add_response(url="http://test_url", data=b"test content")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -63,8 +63,8 @@ def test_with_one_response(httpx_mock: HTTPXMock):
 
 
 def test_with_many_responses(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", data=b"test content 2")
+    httpx_mock.add_response(url="http://test_url", data=b"test content 1")
+    httpx_mock.add_response(url="http://test_url", data=b"test content 2")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -78,12 +78,20 @@ def test_with_many_responses(httpx_mock: HTTPXMock):
 
 
 def test_with_many_responses_methods(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
-    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
-    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
-    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
+    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(
+        url="http://test_url", method="POST", data=b"test content 2"
+    )
+    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(
+        url="http://test_url", method="DELETE", data=b"test content 4"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="PATCH", data=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", data=b"test content 6"
+    )
 
     with httpx.Client() as client:
         response = client.post("http://test_url")
@@ -107,22 +115,22 @@ def test_with_many_responses_methods(httpx_mock: HTTPXMock):
 
 def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", data=b"test content 1", status_code=200
+        url="http://test_url", method="GET", data=b"test content 1", status_code=200
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", data=b"test content 2", status_code=201
+        url="http://test_url", method="POST", data=b"test content 2", status_code=201
     )
     httpx_mock.add_response(
-        "http://test_url", method="PUT", data=b"test content 3", status_code=202
+        url="http://test_url", method="PUT", data=b"test content 3", status_code=202
     )
     httpx_mock.add_response(
-        "http://test_url", method="DELETE", data=b"test content 4", status_code=303
+        url="http://test_url", method="DELETE", data=b"test content 4", status_code=303
     )
     httpx_mock.add_response(
-        "http://test_url", method="PATCH", data=b"test content 5", status_code=404
+        url="http://test_url", method="PATCH", data=b"test content 5", status_code=404
     )
     httpx_mock.add_response(
-        "http://test_url", method="HEAD", data=b"test content 6", status_code=500
+        url="http://test_url", method="HEAD", data=b"test content 6", status_code=500
     )
 
     with httpx.Client() as client:
@@ -153,22 +161,22 @@ def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
 
 def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url?param1=test", method="GET", data=b"test content 1"
+        url="http://test_url?param1=test", method="GET", data=b"test content 1"
     )
     httpx_mock.add_response(
-        "http://test_url?param2=test", method="POST", data=b"test content 2"
+        url="http://test_url?param2=test", method="POST", data=b"test content 2"
     )
     httpx_mock.add_response(
-        "http://test_url?param3=test", method="PUT", data=b"test content 3"
+        url="http://test_url?param3=test", method="PUT", data=b"test content 3"
     )
     httpx_mock.add_response(
-        "http://test_url?param4=test", method="DELETE", data=b"test content 4"
+        url="http://test_url?param4=test", method="DELETE", data=b"test content 4"
     )
     httpx_mock.add_response(
-        "http://test_url?param5=test", method="PATCH", data=b"test content 5"
+        url="http://test_url?param5=test", method="PATCH", data=b"test content 5"
     )
     httpx_mock.add_response(
-        "http://test_url?param6=test", method="HEAD", data=b"test content 6"
+        url="http://test_url?param6=test", method="HEAD", data=b"test content 6"
     )
 
     with httpx.Client() as client:
@@ -194,8 +202,8 @@ def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
 
 
 def test_response_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(re.compile(".*test.*"))
-    httpx_mock.add_response("http://unmatched", data=b"test content")
+    httpx_mock.add_response(url=re.compile(".*test.*"))
+    httpx_mock.add_response(url="http://unmatched", data=b"test content")
 
     with httpx.Client() as client:
         response = client.get("http://unmatched")
@@ -206,27 +214,27 @@ def test_response_with_pattern_in_url(httpx_mock: HTTPXMock):
 
 
 def test_request_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
-    httpx_mock.add_response("http://unmatched")
+    httpx_mock.add_response(url="http://test_url")
+    httpx_mock.add_response(url="http://unmatched")
 
     with httpx.Client() as client:
         client.get("http://unmatched")
         client.get("http://test_url", headers={"X-Test": "1"})
 
-    assert httpx_mock.get_request(re.compile(".*test.*")).headers["x-test"] == "1"
+    assert httpx_mock.get_request(url=re.compile(".*test.*")).headers["x-test"] == "1"
 
 
 def test_requests_with_pattern_in_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
-    httpx_mock.add_response("http://tests_url")
-    httpx_mock.add_response("http://unmatched")
+    httpx_mock.add_response(url="http://test_url")
+    httpx_mock.add_response(url="http://tests_url")
+    httpx_mock.add_response(url="http://unmatched")
 
     with httpx.Client() as client:
         client.get("http://tests_url", headers={"X-Test": "1"})
         client.get("http://unmatched", headers={"X-Test": "2"})
         client.get("http://test_url")
 
-    requests = httpx_mock.get_requests(re.compile(".*test.*"))
+    requests = httpx_mock.get_requests(url=re.compile(".*test.*"))
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "1"
     assert "x-test" not in requests[1].headers
@@ -255,8 +263,8 @@ def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, re.compile(".*test.*"))
-    httpx_mock.add_callback(custom_response2, "http://unmatched")
+    httpx_mock.add_callback(custom_response, url=re.compile(".*test.*"))
+    httpx_mock.add_callback(custom_response2, url="http://unmatched")
 
     with httpx.Client() as client:
         response = client.get("http://unmatched")
@@ -268,32 +276,32 @@ def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
 
 def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param1": "test"}),
+        url=httpx.URL("http://test_url", params={"param1": "test"}),
         method="GET",
         data=b"test content 1",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param2": "test"}),
+        url=httpx.URL("http://test_url", params={"param2": "test"}),
         method="POST",
         data=b"test content 2",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param3": "test"}),
+        url=httpx.URL("http://test_url", params={"param3": "test"}),
         method="PUT",
         data=b"test content 3",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param4": "test"}),
+        url=httpx.URL("http://test_url", params={"param4": "test"}),
         method="DELETE",
         data=b"test content 4",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param5": "test"}),
+        url=httpx.URL("http://test_url", params={"param5": "test"}),
         method="PATCH",
         data=b"test content 5",
     )
     httpx_mock.add_response(
-        httpx.URL("http://test_url", params={"param6": "test"}),
+        url=httpx.URL("http://test_url", params={"param6": "test"}),
         method="HEAD",
         data=b"test content 6",
     )
@@ -320,7 +328,7 @@ def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
 
 def test_with_http_version_2(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", http_version="HTTP/2", data=b"test content 1"
+        url="http://test_url", http_version="HTTP/2", data=b"test content 1"
     )
 
     with httpx.Client() as client:
@@ -331,7 +339,7 @@ def test_with_http_version_2(httpx_mock: HTTPXMock):
 
 def test_with_headers(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
+        url="http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
     )
 
     with httpx.Client() as client:
@@ -341,14 +349,14 @@ def test_with_headers(httpx_mock: HTTPXMock):
 
 
 def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", data={"key1": "value1"})
+    httpx_mock.add_response(url="http://test_url", data={"key1": "value1"})
     httpx_mock.add_response(
-        "http://test_url",
+        url="http://test_url",
         files={"file1": "content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
     httpx_mock.add_response(
-        "http://test_url",
+        url="http://test_url",
         data={"key1": "value1"},
         files={"file1": "content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
@@ -382,12 +390,20 @@ content of file 1\r
 
 
 def test_requests_retrieval(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url", method="GET", data=b"test content 1")
-    httpx_mock.add_response("http://test_url", method="POST", data=b"test content 2")
-    httpx_mock.add_response("http://test_url", method="PUT", data=b"test content 3")
-    httpx_mock.add_response("http://test_url", method="DELETE", data=b"test content 4")
-    httpx_mock.add_response("http://test_url", method="PATCH", data=b"test content 5")
-    httpx_mock.add_response("http://test_url", method="HEAD", data=b"test content 6")
+    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(
+        url="http://test_url", method="POST", data=b"test content 2"
+    )
+    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(
+        url="http://test_url", method="DELETE", data=b"test content 4"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="PATCH", data=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", data=b"test content 6"
+    )
 
     with httpx.Client() as client:
         client.post("http://test_url", data=b"sent content 2")
@@ -398,36 +414,43 @@ def test_requests_retrieval(httpx_mock: HTTPXMock):
         client.delete("http://test_url", headers={"X-Test": "test header 4"})
 
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "PATCH").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PATCH").read()
         == b"sent content 5"
     )
-    assert httpx_mock.get_request(httpx.URL("http://test_url"), "HEAD").read() == b""
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "PUT").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="HEAD").read()
+        == b""
+    )
+    assert (
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PUT").read()
         == b"sent content 3"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "GET").headers["x-test"]
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="GET").headers[
+            "x-test"
+        ]
         == "test header 1"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "POST").read()
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="POST").read()
         == b"sent content 2"
     )
     assert (
-        httpx_mock.get_request(httpx.URL("http://test_url"), "DELETE").headers["x-test"]
+        httpx_mock.get_request(
+            url=httpx.URL("http://test_url"), method="DELETE"
+        ).headers["x-test"]
         == "test header 4"
     )
 
 
 def test_requests_retrieval_on_same_url(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response(url="http://test_url")
 
     with httpx.Client() as client:
         client.get("http://test_url", headers={"X-TEST": "test header 1"})
         client.get("http://test_url", headers={"X-TEST": "test header 2"})
 
-    requests = httpx_mock.get_requests(httpx.URL("http://test_url"))
+    requests = httpx_mock.get_requests(url=httpx.URL("http://test_url"))
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "test header 1"
     assert requests[1].headers["x-test"] == "test header 2"
@@ -477,7 +500,7 @@ def test_requests_retrieval_on_same_url_and_method(httpx_mock: HTTPXMock):
         client.post("http://test_url", headers={"X-TEST": "test header 3"})
         client.get("http://test_url2", headers={"X-TEST": "test header 4"})
 
-    requests = httpx_mock.get_requests(httpx.URL("http://test_url"), "GET")
+    requests = httpx_mock.get_requests(url=httpx.URL("http://test_url"), method="GET")
     assert len(requests) == 2
     assert requests[0].headers["x-test"] == "test header 1"
     assert requests[1].headers["x-test"] == "test header 2"
@@ -508,12 +531,14 @@ def test_default_request_retrieval(httpx_mock: HTTPXMock):
 
 def test_requests_json_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        "http://test_url", method="GET", json=["list content 1", "list content 2"]
+        url="http://test_url", method="GET", json=["list content 1", "list content 2"]
     )
     httpx_mock.add_response(
-        "http://test_url", method="POST", json={"key 1": "value 1", "key 2": "value 2"}
+        url="http://test_url",
+        method="POST",
+        json={"key 1": "value 1", "key 2": "value 2"},
     )
-    httpx_mock.add_response("http://test_url", method="PUT", json="string value")
+    httpx_mock.add_response(url="http://test_url", method="PUT", json="string value")
 
     with httpx.Client() as client:
         response = client.post("http://test_url")
@@ -532,7 +557,7 @@ def test_callback_raising_exception(httpx_mock: HTTPXMock):
     ) -> httpx.Response:
         raise httpx.exceptions.TimeoutException()
 
-    httpx_mock.add_callback(raise_timeout, "http://test_url")
+    httpx_mock.add_callback(raise_timeout, url="http://test_url")
 
     with httpx.Client() as client:
         with pytest.raises(httpx.exceptions.TimeoutException):
@@ -551,7 +576,7 @@ def test_callback_returning_response(httpx_mock: HTTPXMock):
             request=request,
         )
 
-    httpx_mock.add_callback(custom_response, "http://test_url")
+    httpx_mock.add_callback(custom_response, url="http://test_url")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -613,4 +638,4 @@ def test_request_retrieval_with_more_than_one(httpx_mock: HTTPXMock):
         client.get("http://test_url", headers={"X-TEST": "test header 1"})
         client.get("http://test_url", headers={"X-TEST": "test header 2"})
 
-    httpx_mock.get_request(httpx.URL("http://test_url"))
+    httpx_mock.get_request(url=httpx.URL("http://test_url"))

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -7,11 +7,14 @@ from pytest_httpx import httpx_mock, HTTPXMock
     raises=AssertionError, reason="Unused responses should fail test case."
 )
 def test_httpx_mock_unused_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response("http://test_url")
+    httpx_mock.add_response()
 
 
 @pytest.mark.xfail(
     raises=AssertionError, reason="Unused callbacks should fail test case."
 )
 def test_httpx_mock_unused_callback(httpx_mock: HTTPXMock):
-    httpx_mock.add_callback(lambda r, t: None, "http://test_url")
+    def unused(*args, **kwargs):
+        pass
+
+    httpx_mock.add_callback(unused)


### PR DESCRIPTION
### Changed
- url is not a mandatory parameter for response registration anymore.
- url is not a mandatory parameter for callback registration anymore.
- url is not a mandatory parameter for request retrieval anymore.
- method does not have a default value for response registration anymore.
- method does not have a default value for callback registration anymore.
- method does not have a default value for request retrieval anymore.
- url and methods are not positional arguments anymore.
