### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2020-07-31
 ### Changed
 - requires [`pytest`](https://docs.pytest.org/en/latest/) 6.
+- `assert_and_reset` mock method has been renamed to `reset` and now takes a boolean parameter to specify if assertion should be performed.
+
+### Added
+- It is now possible to disable the assertion that all registered responses were requested thanks to the `assert_all_responses_were_requested` fixture. Refer to documentation for more details.
 
 ### Removed
 - It is not possible to provide an URL encoded response anymore by providing a dictionary in `data` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - requires [`pytest`](https://docs.pytest.org/en/latest/) 6.
 
+### Removed
+- It is not possible to provide an URL encoded response anymore by providing a dictionary in `data` parameter.
+
 ## [0.4.0] - 2020-06-05
 ### Changed
 - `httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture does not need to be explicitly imported anymore (many thanks to [`Thomas LÉVEIL`](https://github.com/thomasleveil)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2020-07-31
+### Changed
+- requires [`pytest`](https://docs.pytest.org/en/latest/) 6.
+
 ## [0.4.0] - 2020-06-05
 ### Changed
 - `httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixture does not need to be explicitly imported anymore (many thanks to [`Thomas LÉVEIL`](https://github.com/thomasleveil)).
@@ -73,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-75 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-79 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-72 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-75 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -30,7 +30,6 @@ Once installed, `httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixt
 
 You can register responses for both sync and async [`HTTPX`](https://www.python-httpx.org) requests.
 
-
 ```python
 import pytest
 import httpx
@@ -52,6 +51,16 @@ async def test_something_async(httpx_mock):
 ```
 
 If all registered responses are not sent back during test execution, the test case will fail at teardown.
+
+This behavior can be disabled thanks to the `assert_all_responses_were_requested` fixture:
+
+```python
+import pytest
+
+@pytest.fixture
+def assert_all_responses_were_requested() -> bool:
+    return False
+```
 
 Default response is a HTTP/1.1 200 (OK) without any body.
 
@@ -297,6 +306,16 @@ Callback should expect at least two parameters:
  * timeout: The [timeouts](https://www.python-httpx.org/advanced/#timeout-configuration) linked to the request.
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
+
+This behavior can be disabled thanks to the `assert_all_responses_were_requested` fixture:
+
+```python
+import pytest
+
+@pytest.fixture
+def assert_all_responses_were_requested() -> bool:
+    return False
+```
 
 ### Dynamic responses
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ def test_bytes_body(httpx_mock: HTTPXMock):
 
 ### Add multipart response
 
-Use `data` parameter as a dictionary or `files` parameter (or both) to send multipart response.
+Use `files` parameter (and optionally `data` parameter as a dictionary) to send multipart response.
 
 You can specify `boundary` parameter to specify the multipart boundary to use.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,35 @@ def test_bytes_body(httpx_mock: HTTPXMock):
     
 ```
 
+### Reply by streaming data
+
+Use `data` parameter to stream chunks that you specify.
+As long as your data is an iterable it will stream your data.
+
+```python
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+
+def test_sync_streaming(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(data=[b"part 1", b"part 2"])
+
+    with httpx.Client() as client:
+        with client.stream(method="GET", url="http://test_url") as response:
+            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+
+
+@pytest.mark.asyncio
+async def test_async_streaming(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(data=[b"part 1", b"part 2"])
+
+    async with httpx.AsyncClient() as client:
+        async with client.stream(method="GET", url="http://test_url") as response:
+            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+    
+```
+
 ### Add multipart response
 
 Use `files` parameter (and optionally `data` parameter as a dictionary) to send multipart response.

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,16 +1,26 @@
 import httpx
 import pytest
 
-from pytest_httpx._httpx_mock import HTTPXMock, to_response, _PytestSyncTransport, _PytestAsyncTransport
+from pytest_httpx._httpx_mock import (
+    HTTPXMock,
+    to_response,
+    _PytestSyncTransport,
+    _PytestAsyncTransport,
+)
 from pytest_httpx.version import __version__
 
 
 @pytest.fixture
-def httpx_mock(monkeypatch) -> HTTPXMock:
+def assert_all_responses_were_requested() -> bool:
+    return True
+
+
+@pytest.fixture
+def httpx_mock(monkeypatch, assert_all_responses_were_requested: bool) -> HTTPXMock:
     mock = HTTPXMock()
     # Mock synchronous requests
     monkeypatch.setattr(
-        httpx.Client, "transport_for_url", lambda self, url: _PytestSyncTransport(mock),
+        httpx.Client, "transport_for_url", lambda self, url: _PytestSyncTransport(mock)
     )
     # Mock asynchronous requests
     monkeypatch.setattr(
@@ -19,4 +29,4 @@ def httpx_mock(monkeypatch) -> HTTPXMock:
         lambda self, url: _PytestAsyncTransport(mock),
     )
     yield mock
-    mock.assert_and_reset()
+    mock.reset(assert_all_responses_were_requested)

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -10,9 +10,6 @@ class ByteStream(httpcore.AsyncByteStream, httpcore.SyncByteStream):
         httpcore.SyncByteStream.__init__(self)
         self.data = data
 
-    def can_replay(self) -> bool:
-        return True
-
     def __iter__(self) -> Iterator[bytes]:
         yield self.data
 
@@ -24,9 +21,6 @@ class IteratorStream(httpcore.AsyncByteStream, httpcore.SyncByteStream):
     def __init__(self, iterator):
         httpcore.AsyncByteStream.__init__(self, aiterator=iterator)
         httpcore.SyncByteStream.__init__(self, iterator=iterator)
-
-    def can_replay(self) -> bool:
-        return False
 
 
 def stream(

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -1,0 +1,52 @@
+from typing import Union, Any, Iterator, AsyncIterator
+from json import dumps
+
+import httpcore
+
+
+class ByteStream(httpcore.AsyncByteStream, httpcore.SyncByteStream):
+    def __init__(self, data: bytes):
+        httpcore.AsyncByteStream.__init__(self)
+        httpcore.SyncByteStream.__init__(self)
+        self.data = data
+
+    def can_replay(self) -> bool:
+        return True
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield self.data
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield self.data
+
+
+class IteratorStream(httpcore.AsyncByteStream, httpcore.SyncByteStream):
+    def __init__(self, iterator):
+        httpcore.AsyncByteStream.__init__(self, aiterator=iterator)
+        httpcore.SyncByteStream.__init__(self, iterator=iterator)
+
+    def can_replay(self) -> bool:
+        return False
+
+
+def stream(
+    data, files, json: Any, boundary: bytes
+) -> Union[httpcore.AsyncByteStream, httpcore.SyncByteStream]:
+    if files:
+        # TODO Get rid of this internal import
+        # import is performed at runtime when needed to reduce impact of internal changes in httpx
+        from httpx._content_streams import MultipartStream
+
+        return MultipartStream(data=data or {}, files=files, boundary=boundary)
+
+    if json is not None:
+        data = dumps(json).encode("utf-8")
+    elif isinstance(data, str):
+        data = data.encode("utf-8")
+    elif data is None:
+        data = b""
+
+    if isinstance(data, bytes):
+        return ByteStream(data)
+
+    return IteratorStream(data)

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ setup(
     ],
     keywords=["pytest", "testing", "mock", "httpx"],
     packages=find_packages(exclude=["tests*"]),
-    entry_points={'pytest11': ['pytest_httpx = pytest_httpx']},
-    install_requires=["httpx==0.13.*", "pytest>=5.4.*,<6.*"],
+    entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
+    install_requires=["httpx==0.13.*", "pytest==6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions
-            "pytest-asyncio==0.12.*",
+            "pytest-asyncio==0.14.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -12,8 +12,8 @@ async def test_without_response(httpx_mock: HTTPXMock):
         async with httpx.AsyncClient() as client:
             await client.get("http://test_url")
     assert (
-            str(exception_info.value)
-            == "No mock can be found for GET request on http://test_url."
+        str(exception_info.value)
+        == "No mock can be found for GET request on http://test_url."
     )
 
 
@@ -358,7 +358,6 @@ async def test_with_headers(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data={"key1": "value1"})
     httpx_mock.add_response(
         url="http://test_url",
         files={"file1": "content of file 1"},
@@ -373,18 +372,15 @@ async def test_multipart_body(httpx_mock: HTTPXMock):
 
     async with httpx.AsyncClient() as client:
         response = await client.get("http://test_url")
-        assert response.text == "key1=value1"
-
-        response = await client.get("http://test_url")
         assert (
-                response.text
-                == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
+            response.text
+            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
         )
 
         response = await client.get("http://test_url")
         assert (
-                response.text
-                == """--2256d3a36d2a61a1eba35a22bee5c74a\r
+            response.text
+            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
 Content-Disposition: form-data; name="key1"\r
 \r
 value1\r
@@ -424,32 +420,32 @@ async def test_requests_retrieval(httpx_mock: HTTPXMock):
         await client.delete("http://test_url", headers={"X-Test": "test header 4"})
 
     assert (
-            httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PATCH").read()
-            == b"sent content 5"
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PATCH").read()
+        == b"sent content 5"
     )
     assert (
-            httpx_mock.get_request(url=httpx.URL("http://test_url"), method="HEAD").read()
-            == b""
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="HEAD").read()
+        == b""
     )
     assert (
-            httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PUT").read()
-            == b"sent content 3"
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="PUT").read()
+        == b"sent content 3"
     )
     assert (
-            httpx_mock.get_request(url=httpx.URL("http://test_url"), method="GET").headers[
-                "x-test"
-            ]
-            == "test header 1"
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="GET").headers[
+            "x-test"
+        ]
+        == "test header 1"
     )
     assert (
-            httpx_mock.get_request(url=httpx.URL("http://test_url"), method="POST").read()
-            == b"sent content 2"
+        httpx_mock.get_request(url=httpx.URL("http://test_url"), method="POST").read()
+        == b"sent content 2"
     )
     assert (
-            httpx_mock.get_request(
-                url=httpx.URL("http://test_url"), method="DELETE"
-            ).headers["x-test"]
-            == "test header 4"
+        httpx_mock.get_request(
+            url=httpx.URL("http://test_url"), method="DELETE"
+        ).headers["x-test"]
+        == "test header 4"
     )
 
 
@@ -584,7 +580,7 @@ async def test_callback_raising_exception(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_callback_returning_response(httpx_mock: HTTPXMock):
     def custom_response(request: httpx.Request, *args, **kwargs):
-        return to_response(json={"url": str(request.url)}, )
+        return to_response(json={"url": str(request.url)})
 
     httpx_mock.add_callback(custom_response, url="http://test_url")
 
@@ -596,7 +592,7 @@ async def test_callback_returning_response(httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_callback_executed_twice(httpx_mock: HTTPXMock):
     def custom_response(*args, **kwargs):
-        return to_response(json=["content"], )
+        return to_response(json=["content"])
 
     httpx_mock.add_callback(custom_response)
 
@@ -627,7 +623,8 @@ def test_request_retrieval_with_more_than_one(testdir):
     """
     Single request cannot be returned if there is more than one matching.
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
         import httpx
         
@@ -641,12 +638,15 @@ def test_request_retrieval_with_more_than_one(testdir):
                 await client.get("http://test_url", headers={"X-TEST": "test header 2"})
         
             httpx_mock.get_request(url=httpx.URL("http://test_url"))
-    """)
+    """
+    )
     result = testdir.runpytest()
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines([
-        '*AssertionError: More than one request (2) matched, use get_requests instead.'
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "*AssertionError: More than one request (2) matched, use get_requests instead."
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -674,8 +674,8 @@ async def test_headers_not_matching(httpx_mock: HTTPXMock):
         with pytest.raises(httpx.HTTPError) as exception_info:
             await client.get("http://test_url")
         assert (
-                str(exception_info.value)
-                == "No mock can be found for GET request on http://test_url."
+            str(exception_info.value)
+            == "No mock can be found for GET request on http://test_url."
         )
 
     # Clean up responses to avoid assertion failure
@@ -699,8 +699,8 @@ async def test_content_not_matching(httpx_mock: HTTPXMock):
         with pytest.raises(httpx.HTTPError) as exception_info:
             await client.post("http://test_url", data=b"This is the body2")
         assert (
-                str(exception_info.value)
-                == "No mock can be found for POST request on http://test_url."
+            str(exception_info.value)
+            == "No mock can be found for POST request on http://test_url."
         )
 
     # Clean up responses to avoid assertion failure

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -66,6 +66,24 @@ async def test_with_one_response(httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_response_with_string_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url", data="test content")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://test_url")
+        assert response.content == b"test content"
+
+
+@pytest.mark.asyncio
+async def test_response_streaming(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url", data=[b"part 1", b"part 2"])
+
+    async with httpx.AsyncClient() as client:
+        async with client.stream(method="GET", url="http://test_url") as response:
+            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+
+
+@pytest.mark.asyncio
 async def test_with_many_responses(httpx_mock: HTTPXMock):
     httpx_mock.add_response(url="http://test_url", data=b"test content 1")
     httpx_mock.add_response(url="http://test_url", data=b"test content 2")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -243,7 +243,7 @@ def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
         return to_response(json={"url": str(request.url)})
 
     def custom_response2(request: httpx.Request, *args, **kwargs):
-        return to_response(http_version="HTTP/2.0", json={"url": str(request.url)},)
+        return to_response(http_version="HTTP/2.0", json={"url": str(request.url)})
 
     httpx_mock.add_callback(custom_response, url=re.compile(".*test.*"))
     httpx_mock.add_callback(custom_response2, url="http://unmatched")
@@ -331,7 +331,6 @@ def test_with_headers(httpx_mock: HTTPXMock):
 
 
 def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data={"key1": "value1"})
     httpx_mock.add_response(
         url="http://test_url",
         files={"file1": "content of file 1"},
@@ -345,9 +344,6 @@ def test_multipart_body(httpx_mock: HTTPXMock):
     )
 
     with httpx.Client() as client:
-        response = client.get("http://test_url")
-        assert response.text == "key1=value1"
-
         response = client.get("http://test_url")
         assert (
             response.text
@@ -587,7 +583,8 @@ def test_request_retrieval_with_more_than_one(testdir):
     """
     Single request cannot be returned if there is more than one matching.
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import httpx
         
         
@@ -599,12 +596,15 @@ def test_request_retrieval_with_more_than_one(testdir):
                 client.get("http://test_url", headers={"X-TEST": "test header 2"})
         
             httpx_mock.get_request(url=httpx.URL("http://test_url"))
-    """)
+    """
+    )
     result = testdir.runpytest()
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines([
-        '*AssertionError: More than one request (2) matched, use get_requests instead.'
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "*AssertionError: More than one request (2) matched, use get_requests instead."
+        ]
+    )
 
 
 def test_headers_matching(httpx_mock: HTTPXMock):

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -60,6 +60,22 @@ def test_with_one_response(httpx_mock: HTTPXMock):
         assert response.content == b"test content"
 
 
+def test_response_with_string_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url", data="test content")
+
+    with httpx.Client() as client:
+        response = client.get("http://test_url")
+        assert response.content == b"test content"
+
+
+def test_response_streaming(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url="http://test_url", data=[b"part 1", b"part 2"])
+
+    with httpx.Client() as client:
+        with client.stream(method="GET", url="http://test_url") as response:
+            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+
+
 def test_with_many_responses(httpx_mock: HTTPXMock):
     httpx_mock.add_response(url="http://test_url", data=b"test content 1")
     httpx_mock.add_response(url="http://test_url", data=b"test content 2")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,7 @@
 def test_fixture_is_available(testdir):
     # create a temporary pytest test file
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import httpx
         
         
@@ -9,7 +10,8 @@ def test_fixture_is_available(testdir):
             r = httpx.get("http://foo.tld")
             assert httpx_mock.get_request() is not None
 
-    """)
+    """
+    )
 
     # run all tests with pytest
     result = testdir.runpytest()
@@ -20,31 +22,35 @@ def test_httpx_mock_unused_response(testdir):
     """
     Unused responses should fail test case.
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_httpx_mock_unused_response(httpx_mock):
             httpx_mock.add_response()
-    """)
+    """
+    )
     result = testdir.runpytest()
-    result.assert_outcomes(error=1, passed=1)
-    result.stdout.fnmatch_lines([
-        '*AssertionError: The following responses are mocked but not requested: *'
-    ])
+    result.assert_outcomes(errors=1, passed=1)
+    result.stdout.fnmatch_lines(
+        ["*AssertionError: The following responses are mocked but not requested: *"]
+    )
 
 
 def test_httpx_mock_unused_callback(testdir):
     """
     Unused callbacks should fail test case.
     """
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         def test_httpx_mock_unused_callback(httpx_mock):
             def unused(*args, **kwargs):
                 pass
         
             httpx_mock.add_callback(unused)
 
-    """)
+    """
+    )
     result = testdir.runpytest()
-    result.assert_outcomes(error=1, passed=1)
-    result.stdout.fnmatch_lines([
-        '*AssertionError: The following callbacks are registered but not executed: *'
-    ])
+    result.assert_outcomes(errors=1, passed=1)
+    result.stdout.fnmatch_lines(
+        ["*AssertionError: The following callbacks are registered but not executed: *"]
+    )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -35,6 +35,26 @@ def test_httpx_mock_unused_response(testdir):
     )
 
 
+def test_httpx_mock_unused_response_without_assertion(testdir):
+    """
+    Unused responses should not fail test case if assert_all_responses_were_requested fixture is set to False.
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.fixture
+        def assert_all_responses_were_requested() -> bool:
+            return False
+
+        def test_httpx_mock_unused_response_without_assertion(httpx_mock):
+            httpx_mock.add_response()
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+
 def test_httpx_mock_unused_callback(testdir):
     """
     Unused callbacks should fail test case.
@@ -54,3 +74,27 @@ def test_httpx_mock_unused_callback(testdir):
     result.stdout.fnmatch_lines(
         ["*AssertionError: The following callbacks are registered but not executed: *"]
     )
+
+
+def test_httpx_mock_unused_callback_without_assertion(testdir):
+    """
+    Unused callbacks should not fail test case if assert_all_responses_were_requested fixture is set to False.
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.fixture
+        def assert_all_responses_were_requested() -> bool:
+            return False
+
+        def test_httpx_mock_unused_callback_without_assertion(httpx_mock):
+            def unused(*args, **kwargs):
+                pass
+        
+            httpx_mock.add_callback(unused)
+
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
### Changed
- requires [`pytest`](https://docs.pytest.org/en/latest/) 6.
- `assert_and_reset` mock method has been renamed to `reset` and now takes a boolean parameter to specify if assertion should be performed.

### Added
- It is now possible to disable the assertion that all registered responses were requested thanks to the `assert_all_responses_were_requested` fixture. Refer to documentation for more details. (fixes #15 )

### Removed
- It is not possible to provide an URL encoded response anymore by providing a dictionary in `data` parameter.
