### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `non_mocked_hosts` fixture allowing to avoid mocking requests sent on some specific hosts.
 
 ## [0.7.0] - 2020-08-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2020-08-26
 ### Added
 - `non_mocked_hosts` fixture allowing to avoid mocking requests sent on some specific hosts.
+
+### Changed
+- Display the matchers that were not matched instead of the responses that were not sent.
 
 ## [0.7.0] - 2020-08-13
 ### Changed
@@ -94,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/pytest_httpx.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-121 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/pytest_httpx"><img alt="Number of tests" src="https://img.shields.io/badge/tests-123 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Once installed, `httpx_mock` [`pytest`](https://docs.pytest.org/en/latest/) fixt
 - [Add dynamic responses](#dynamic-responses)
 - [Raising exceptions](#raising-exceptions)
 - [Check requests](#check-sent-requests)
+- [Do not mock some requests](#do-not-mock-some-requests)
 - [Migrating](#migrating-to-pytest-httpx)
   - [responses](#from-responses)
   - [aioresponses](#from-aioresponses)
@@ -500,6 +501,44 @@ Matching is performed on equality for each provided header.
 Use `match_content` parameter to specify the full HTTP body executing the callback.
 
 Matching is performed on equality.
+
+## Do not mock some requests
+
+By default, `pytest-httpx` will mock every request.
+
+But, for instance, in case you want to write integration tests with other servers, you might want to let some requests go through.
+
+To do so, you can use the `non_mocked_hosts` fixture:
+
+```python
+import pytest
+
+@pytest.fixture
+def non_mocked_hosts() -> list:
+    return ["my_local_test_host", "my_other_test_host"]
+```
+
+Every other requested hosts will be mocked as in the following example
+
+```python
+import pytest
+import httpx
+
+@pytest.fixture
+def non_mocked_hosts() -> list:
+    return ["my_local_test_host"]
+
+
+def test_partial_mock(httpx_mock):
+    httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        # This request will NOT be mocked
+        response1 = client.get("https://www.my_local_test_host/sub?param=value")
+        # This request will be mocked
+        response2 = client.get("http://test_url")
+```
+
 
 ## Migrating to pytest-httpx
 

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import httpx
 import pytest
 
@@ -16,17 +18,39 @@ def assert_all_responses_were_requested() -> bool:
 
 
 @pytest.fixture
-def httpx_mock(monkeypatch, assert_all_responses_were_requested: bool) -> HTTPXMock:
+def non_mocked_hosts() -> list:
+    return []
+
+
+@pytest.fixture
+def httpx_mock(
+    monkeypatch, assert_all_responses_were_requested: bool, non_mocked_hosts: List[str]
+) -> HTTPXMock:
+    # Ensure redirections to www hosts are handled transparently.
+    missing_www = [
+        f"www.{host}" for host in non_mocked_hosts if not host.startswith("www.")
+    ]
+    non_mocked_hosts += missing_www
+
     mock = HTTPXMock()
+
     # Mock synchronous requests
+    real_sync_transport = httpx.Client._transport_for_url
     monkeypatch.setattr(
-        httpx.Client, "_transport_for_url", lambda self, url: _PytestSyncTransport(mock)
+        httpx.Client,
+        "_transport_for_url",
+        lambda self, url: real_sync_transport(self, url)
+        if url.host in non_mocked_hosts
+        else _PytestSyncTransport(mock),
     )
     # Mock asynchronous requests
+    real_async_transport = httpx.AsyncClient._transport_for_url
     monkeypatch.setattr(
         httpx.AsyncClient,
         "_transport_for_url",
-        lambda self, url: _PytestAsyncTransport(mock),
+        lambda self, url: real_async_transport(self, url)
+        if url.host in non_mocked_hosts
+        else _PytestAsyncTransport(mock),
     )
     yield mock
     mock.reset(assert_all_responses_were_requested)

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -31,7 +31,10 @@ def test_httpx_mock_unused_response(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(errors=1, passed=1)
     result.stdout.fnmatch_lines(
-        ["*AssertionError: The following responses are mocked but not requested: *"]
+        [
+            "*AssertionError: The following responses are mocked but not requested:",
+            "*Match all requests",
+        ]
     )
 
 
@@ -72,7 +75,10 @@ def test_httpx_mock_unused_callback(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(errors=1, passed=1)
     result.stdout.fnmatch_lines(
-        ["*AssertionError: The following callbacks are registered but not executed: *"]
+        [
+            "*AssertionError: The following responses are mocked but not requested:",
+            "*Match all requests",
+        ]
     )
 
 


### PR DESCRIPTION
### Added
- `non_mocked_hosts` fixture allowing to avoid mocking requests sent on some specific hosts. Closes #28 

### Changed
- Display the matchers that were not matched instead of the responses that were not sent.
