### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-09-22
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.15.*
+- Callbacks are now called with `ext` dictionary instead of `timeout`. To follow `httpcore` design changes. You can still retrieve timeout by using ```ext['timeout']```
+
 ## [0.8.0] - 2020-08-26
 ### Added
 - `non_mocked_hosts` fixture allowing to avoid mocking requests sent on some specific hosts.
@@ -99,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ from pytest_httpx import HTTPXMock
 
 
 def test_exception_raising(httpx_mock: HTTPXMock):
-    def raise_timeout(request, timeout):
-        raise httpx.ReadTimeout(f"Unable to read within {timeout}", request=request)
+    def raise_timeout(request, ext: dict):
+        raise httpx.ReadTimeout(f"Unable to read within {ext['timeout']}", request=request)
 
     httpx_mock.add_callback(raise_timeout)
     
@@ -616,6 +616,7 @@ Below is a list of parameters that will require a change in your code.
 
 Sample adding a response with `aioresponses`:
 ```python
+import pytest
 from aioresponses import aioresponses
 
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ You can perform custom manipulation upon request reception by registering callba
 
 Callback should expect at least two parameters:
  * request: The received [`httpx.Request`](https://www.python-httpx.org/api/#request).
- * timeout: The [timeouts](https://www.python-httpx.org/advanced/#timeout-configuration) linked to the request.
+ * ext: The extensions (including the [timeouts](https://www.python-httpx.org/advanced/#timeout-configuration)) linked to the request.
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
 
@@ -352,7 +352,7 @@ def assert_all_responses_were_requested() -> bool:
 
 ### Dynamic responses
 
-Callback should return a httpcore response (as a tuple), you can use `pytest_httpx.to_response` function to create such a tuple.
+Callback should return a `httpcore` response (as a tuple), you can use `pytest_httpx.to_response` function to create such a tuple.
 
 ```python
 import httpx
@@ -422,7 +422,7 @@ You can add criteria so that callback will be sent only in case of a more specif
 
 #### Matching on URL
 
-`url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
+`url` parameter can either be a string, a python [`re.Pattern`](https://docs.python.org/3/library/re.html) instance or a [`httpx.URL`](https://www.python-httpx.org/api/#url) instance.
 
 Matching is performed on the full URL, query parameters included.
 

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -16,7 +16,7 @@ def stream(
     if files:
         # TODO Get rid of this internal import
         # import is performed at runtime when needed to reduce impact of internal changes in httpx
-        from httpx._content_streams import MultipartStream
+        from httpx._multipart import MultipartStream
 
         return MultipartStream(data=data or {}, files=files, boundary=boundary)
 

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords=["pytest", "testing", "mock", "httpx"],
     packages=find_packages(exclude=["tests*"]),
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.14.*", "pytest==6.*"],
+    install_requires=["httpx==0.15.*", "pytest==6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -619,14 +619,17 @@ async def test_requests_json_body(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_callback_raising_exception(httpx_mock: HTTPXMock):
-    def raise_timeout(request, timeout):
-        raise httpx.ReadTimeout(f"Unable to read within {timeout}", request=request)
+    def raise_timeout(request, ext):
+        raise httpx.ReadTimeout(
+            f"Unable to read within {ext['timeout']['read']}", request=request
+        )
 
     httpx_mock.add_callback(raise_timeout, url="http://test_url")
 
     async with httpx.AsyncClient() as client:
-        with pytest.raises(httpx.ReadTimeout):
+        with pytest.raises(httpx.ReadTimeout) as exception_info:
             await client.get("http://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -578,14 +578,17 @@ def test_requests_json_body(httpx_mock: HTTPXMock):
 
 
 def test_callback_raising_exception(httpx_mock: HTTPXMock):
-    def raise_timeout(request, timeout):
-        raise httpx.ReadTimeout(f"Unable to read within {timeout}", request=request)
+    def raise_timeout(request, ext):
+        raise httpx.ReadTimeout(
+            f"Unable to read within {ext['timeout']['read']}", request=request
+        )
 
     httpx_mock.add_callback(raise_timeout, url="http://test_url")
 
     with httpx.Client() as client:
-        with pytest.raises(httpx.ReadTimeout):
+        with pytest.raises(httpx.ReadTimeout) as exception_info:
             client.get("http://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
 
 
 def test_callback_returning_response(httpx_mock: HTTPXMock):


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.15.*
- Callbacks are now called with `ext` dictionary instead of `timeout`. To follow `httpcore` design changes. You can still retrieve timeout by using ```ext['timeout']```
