### PR TITLE
Release 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 install:
   - pip install -e .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2021-04-27
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.18.\*
+- `ext` callback parameter was renamed into `extensions`.
+
 ## [0.11.0] - 2021-03-01
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.17.\*
@@ -127,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.9.0...v0.10.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Colin Bounouar
+Copyright (c) 2021 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_headers_matching(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(match_headers={'user-agent': 'python-httpx/0.17.0'})
+    httpx_mock.add_response(match_headers={'user-agent': 'python-httpx/0.18.0'})
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -250,7 +250,7 @@ async def test_async_streaming(httpx_mock: HTTPXMock):
 
     async with httpx.AsyncClient() as client:
         async with client.stream(method="GET", url="http://test_url") as response:
-            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+            assert [part async for part in response.aiter_raw()] == [b"part 1", b"part 2"]
     
 ```
 
@@ -385,7 +385,7 @@ You can perform custom manipulation upon request reception by registering callba
 
 Callback should expect at least two parameters:
  * request: The received [`httpx.Request`](https://www.python-httpx.org/api/#request).
- * ext: The extensions (including the [timeouts](https://www.python-httpx.org/advanced/#timeout-configuration)) linked to the request.
+ * extensions: The extensions (including the [timeouts](https://www.python-httpx.org/advanced/#timeout-configuration)) linked to the request.
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
 
@@ -435,8 +435,8 @@ from pytest_httpx import HTTPXMock
 
 
 def test_exception_raising(httpx_mock: HTTPXMock):
-    def raise_timeout(request, ext: dict):
-        raise httpx.ReadTimeout(f"Unable to read within {ext['timeout']}", request=request)
+    def raise_timeout(request, extensions: dict):
+        raise httpx.ReadTimeout(f"Unable to read within {extensions['timeout']}", request=request)
 
     httpx_mock.add_callback(raise_timeout)
     

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -23,7 +23,12 @@ HeaderTypes = Union[
 
 class IteratorStream(httpcore.AsyncIteratorByteStream, httpcore.IteratorByteStream):
     def __init__(self, iterator):
-        httpcore.AsyncIteratorByteStream.__init__(self, aiterator=iterator)
+        class AsyncIterator:
+            async def __aiter__(self):
+                for chunk in iterator:
+                    yield chunk
+
+        httpcore.AsyncIteratorByteStream.__init__(self, aiterator=AsyncIterator())
         httpcore.IteratorByteStream.__init__(self, iterator=iterator)
 
 
@@ -43,6 +48,6 @@ def stream(
         data = b""
 
     if isinstance(data, bytes):
-        return httpcore.PlainByteStream(data)
+        return httpcore.ByteStream(data)
 
     return IteratorStream(data)

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     keywords=["pytest", "testing", "mock", "httpx"],
     packages=find_packages(exclude=["tests*"]),
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.17.*", "pytest==6.*"],
+    install_requires=["httpx==0.18.*", "pytest==6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -145,7 +145,10 @@ async def test_response_streaming(httpx_mock: HTTPXMock):
 
     async with httpx.AsyncClient() as client:
         async with client.stream(method="GET", url="http://test_url") as response:
-            assert list(response.iter_raw()) == [b"part 1", b"part 2"]
+            assert [part async for part in response.aiter_raw()] == [
+                b"part 1",
+                b"part 2",
+            ]
 
 
 @pytest.mark.asyncio
@@ -653,9 +656,9 @@ async def test_requests_json_body(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_callback_raising_exception(httpx_mock: HTTPXMock):
-    def raise_timeout(request, ext):
+    def raise_timeout(request, extensions):
         raise httpx.ReadTimeout(
-            f"Unable to read within {ext['timeout']['read']}", request=request
+            f"Unable to read within {extensions['timeout']['read']}", request=request
         )
 
     httpx_mock.add_callback(raise_timeout, url="http://test_url")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -610,9 +610,9 @@ def test_requests_json_body(httpx_mock: HTTPXMock):
 
 
 def test_callback_raising_exception(httpx_mock: HTTPXMock):
-    def raise_timeout(request, ext):
+    def raise_timeout(request, extensions):
         raise httpx.ReadTimeout(
-            f"Unable to read within {ext['timeout']['read']}", request=request
+            f"Unable to read within {extensions['timeout']['read']}", request=request
         )
 
     httpx_mock.add_callback(raise_timeout, url="http://test_url")


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.18.\*
- `ext` callback parameter was renamed into `extensions`.
