### PR TITLE
Add py.typed to distribute typing information per PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     ],
     keywords=["pytest", "testing", "mock", "httpx"],
     packages=find_packages(exclude=["tests*"]),
+    package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
     install_requires=["httpx==0.18.*", "pytest==6.*"],
     extras_require={


### PR DESCRIPTION
Currently, importing `pytest_httpx` causes `mypy` errors because no type information is packaged:
```
main.py:1: error: Skipping analyzing "pytest_httpx": found module but no type hints or library stubs
main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```
This PR includes a `py.typed` file so that `mypy` knows to read the annotations directly from the package source files.

My test functions are fully annotated so importing is necessary, e.g.
```python
from httpx_mock import HTTPXMock

def test_something(httpx_mock: HTTPXMock) -> None:
    ...
```

[Relevant section of PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information).
