### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2021-08-19
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.19.\*
+- `files` parameter of `httpx_mock.add_response` now expect dictionary values to be binary (as per [httpx new requirement](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0190-19th-june-2021)).
+
 ## [0.12.1] - 2021-08-11
 ### Fixed
 - Type information is now provided following [PEP 561](https://www.python.org/dev/peps/pep-0561/) (many thanks to [`Caleb Ho`](https://github.com/calebho)).
@@ -136,7 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.10.1...v0.11.0

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_headers_matching(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(match_headers={'user-agent': 'python-httpx/0.18.0'})
+    httpx_mock.add_response(match_headers={'user-agent': 'python-httpx/0.19.0'})
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -266,7 +266,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(data={"key1": "value1"}, files={"file1": "content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
+    httpx_mock.add_response(data={"key1": "value1"}, files={"file1": b"content of file 1"}, boundary=b"2256d3a36d2a61a1eba35a22bee5c74a")
 
     with httpx.Client() as client:
         assert client.get("http://test_url").text == '''--2256d3a36d2a61a1eba35a22bee5c74a\r

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.12.1"
+__version__ = "0.13.0"

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.18.*", "pytest==6.*"],
+    install_requires=["httpx==0.19.*", "pytest==6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions
-            "pytest-asyncio==0.14.*",
+            "pytest-asyncio==0.15.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -446,13 +446,13 @@ async def test_with_headers(httpx_mock: HTTPXMock):
 async def test_multipart_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://test_url",
-        files={"file1": "content of file 1"},
+        files={"file1": b"content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
     httpx_mock.add_response(
         url="http://test_url",
         data={"key1": "value1"},
-        files={"file1": "content of file 1"},
+        files={"file1": b"content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
 

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -410,13 +410,13 @@ def test_with_headers(httpx_mock: HTTPXMock):
 def test_multipart_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://test_url",
-        files={"file1": "content of file 1"},
+        files={"file1": b"content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
     httpx_mock.add_response(
         url="http://test_url",
         data={"key1": "value1"},
-        files={"file1": "content of file 1"},
+        files={"file1": b"content of file 1"},
         boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
     )
 


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.19.\*
- `files` parameter of `httpx_mock.add_response` now expect dictionary values to be binary (as per [httpx new requirement](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0190-19th-june-2021)).
