### PR TITLE
Handle httpx 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.20.\*
 
 ## [0.13.0] - 2021-08-19
 ### Changed

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -5,7 +5,6 @@ import pytest
 
 from pytest_httpx._httpx_mock import (
     HTTPXMock,
-    to_response,
     _PytestSyncTransport,
     _PytestAsyncTransport,
 )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.19.*", "pytest==6.*"],
+    install_requires=["httpx==0.20.*", "pytest==6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -3,7 +3,7 @@ import re
 import httpx
 import pytest
 
-from pytest_httpx import HTTPXMock, to_response
+from pytest_httpx import HTTPXMock
 
 
 def test_without_response(httpx_mock: HTTPXMock):
@@ -111,7 +111,7 @@ Match GET requests"""
 
 
 def test_with_one_response(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data=b"test content")
+    httpx_mock.add_response(url="http://test_url", content=b"test content")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -122,7 +122,7 @@ def test_with_one_response(httpx_mock: HTTPXMock):
 
 
 def test_response_with_string_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data="test content")
+    httpx_mock.add_response(url="http://test_url", content="test content")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -130,7 +130,7 @@ def test_response_with_string_body(httpx_mock: HTTPXMock):
 
 
 def test_response_streaming(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data=[b"part 1", b"part 2"])
+    httpx_mock.add_response(url="http://test_url", content=[b"part 1", b"part 2"])
 
     with httpx.Client() as client:
         with client.stream(method="GET", url="http://test_url") as response:
@@ -138,8 +138,8 @@ def test_response_streaming(httpx_mock: HTTPXMock):
 
 
 def test_with_many_responses(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", data=b"test content 1")
-    httpx_mock.add_response(url="http://test_url", data=b"test content 2")
+    httpx_mock.add_response(url="http://test_url", content=b"test content 1")
+    httpx_mock.add_response(url="http://test_url", content=b"test content 2")
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
@@ -153,19 +153,19 @@ def test_with_many_responses(httpx_mock: HTTPXMock):
 
 
 def test_with_many_responses_methods(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(url="http://test_url", method="GET", content=b"test content 1")
     httpx_mock.add_response(
-        url="http://test_url", method="POST", data=b"test content 2"
+        url="http://test_url", method="POST", content=b"test content 2"
     )
-    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(url="http://test_url", method="PUT", content=b"test content 3")
     httpx_mock.add_response(
-        url="http://test_url", method="DELETE", data=b"test content 4"
-    )
-    httpx_mock.add_response(
-        url="http://test_url", method="PATCH", data=b"test content 5"
+        url="http://test_url", method="DELETE", content=b"test content 4"
     )
     httpx_mock.add_response(
-        url="http://test_url", method="HEAD", data=b"test content 6"
+        url="http://test_url", method="PATCH", content=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", content=b"test content 6"
     )
 
     with httpx.Client() as client:
@@ -190,22 +190,22 @@ def test_with_many_responses_methods(httpx_mock: HTTPXMock):
 
 def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        url="http://test_url", method="GET", data=b"test content 1", status_code=200
+        url="http://test_url", method="GET", content=b"test content 1", status_code=200
     )
     httpx_mock.add_response(
-        url="http://test_url", method="POST", data=b"test content 2", status_code=201
+        url="http://test_url", method="POST", content=b"test content 2", status_code=201
     )
     httpx_mock.add_response(
-        url="http://test_url", method="PUT", data=b"test content 3", status_code=202
+        url="http://test_url", method="PUT", content=b"test content 3", status_code=202
     )
     httpx_mock.add_response(
-        url="http://test_url", method="DELETE", data=b"test content 4", status_code=303
+        url="http://test_url", method="DELETE", content=b"test content 4", status_code=303
     )
     httpx_mock.add_response(
-        url="http://test_url", method="PATCH", data=b"test content 5", status_code=404
+        url="http://test_url", method="PATCH", content=b"test content 5", status_code=404
     )
     httpx_mock.add_response(
-        url="http://test_url", method="HEAD", data=b"test content 6", status_code=500
+        url="http://test_url", method="HEAD", content=b"test content 6", status_code=500
     )
 
     with httpx.Client() as client:
@@ -236,22 +236,22 @@ def test_with_many_responses_status_codes(httpx_mock: HTTPXMock):
 
 def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        url="http://test_url?param1=test", method="GET", data=b"test content 1"
+        url="http://test_url?param1=test", method="GET", content=b"test content 1"
     )
     httpx_mock.add_response(
-        url="http://test_url?param2=test", method="POST", data=b"test content 2"
+        url="http://test_url?param2=test", method="POST", content=b"test content 2"
     )
     httpx_mock.add_response(
-        url="http://test_url?param3=test", method="PUT", data=b"test content 3"
+        url="http://test_url?param3=test", method="PUT", content=b"test content 3"
     )
     httpx_mock.add_response(
-        url="http://test_url?param4=test", method="DELETE", data=b"test content 4"
+        url="http://test_url?param4=test", method="DELETE", content=b"test content 4"
     )
     httpx_mock.add_response(
-        url="http://test_url?param5=test", method="PATCH", data=b"test content 5"
+        url="http://test_url?param5=test", method="PATCH", content=b"test content 5"
     )
     httpx_mock.add_response(
-        url="http://test_url?param6=test", method="HEAD", data=b"test content 6"
+        url="http://test_url?param6=test", method="HEAD", content=b"test content 6"
     )
 
     with httpx.Client() as client:
@@ -278,7 +278,7 @@ def test_with_many_responses_urls_str(httpx_mock: HTTPXMock):
 
 def test_response_with_pattern_in_url(httpx_mock: HTTPXMock):
     httpx_mock.add_response(url=re.compile(".*test.*"))
-    httpx_mock.add_response(url="http://unmatched", data=b"test content")
+    httpx_mock.add_response(url="http://unmatched", content=b"test content")
 
     with httpx.Client() as client:
         response = client.get("http://unmatched")
@@ -317,10 +317,14 @@ def test_requests_with_pattern_in_url(httpx_mock: HTTPXMock):
 
 def test_callback_with_pattern_in_url(httpx_mock: HTTPXMock):
     def custom_response(request: httpx.Request, *args, **kwargs):
-        return to_response(json={"url": str(request.url)})
+        return httpx.Response(status_code=200, json={"url": str(request.url)})
 
     def custom_response2(request: httpx.Request, *args, **kwargs):
-        return to_response(http_version="HTTP/2.0", json={"url": str(request.url)})
+        return httpx.Response(
+            status_code=200,
+            json={"url": str(request.url)},
+            extensions={"http_version": b"HTTP/2.0"},
+        )
 
     httpx_mock.add_callback(custom_response, url=re.compile(".*test.*"))
     httpx_mock.add_callback(custom_response2, url="http://unmatched")
@@ -337,32 +341,32 @@ def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param1": "test"}),
         method="GET",
-        data=b"test content 1",
+        content=b"test content 1",
     )
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param2": "test"}),
         method="POST",
-        data=b"test content 2",
+        content=b"test content 2",
     )
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param3": "test"}),
         method="PUT",
-        data=b"test content 3",
+        content=b"test content 3",
     )
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param4": "test"}),
         method="DELETE",
-        data=b"test content 4",
+        content=b"test content 4",
     )
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param5": "test"}),
         method="PATCH",
-        data=b"test content 5",
+        content=b"test content 5",
     )
     httpx_mock.add_response(
         url=httpx.URL("http://test_url", params={"param6": "test"}),
         method="HEAD",
-        data=b"test content 6",
+        content=b"test content 6",
     )
 
     with httpx.Client() as client:
@@ -387,7 +391,7 @@ def test_with_many_responses_urls_instances(httpx_mock: HTTPXMock):
 
 def test_with_http_version_2(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        url="http://test_url", http_version="HTTP/2", data=b"test content 1"
+        url="http://test_url", http_version="HTTP/2", content=b"test content 1"
     )
 
     with httpx.Client() as client:
@@ -398,66 +402,29 @@ def test_with_http_version_2(httpx_mock: HTTPXMock):
 
 def test_with_headers(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
-        url="http://test_url", data=b"test content 1", headers={"X-Test": "Test value"}
+        url="http://test_url", content=b"test content 1", headers={"X-Test": "Test value"}
     )
 
     with httpx.Client() as client:
         response = client.get("http://test_url")
         assert response.content == b"test content 1"
-        assert response.headers == httpx.Headers({"x-test": "Test value"})
-
-
-def test_multipart_body(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="http://test_url",
-        files={"file1": b"content of file 1"},
-        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-    )
-    httpx_mock.add_response(
-        url="http://test_url",
-        data={"key1": "value1"},
-        files={"file1": b"content of file 1"},
-        boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-    )
-
-    with httpx.Client() as client:
-        response = client.get("http://test_url")
-        assert (
-            response.text
-            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
-        )
-
-        response = client.get("http://test_url")
-        assert (
-            response.text
-            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="key1"\r
-\r
-value1\r
---2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="file1"; filename="upload"\r
-Content-Type: application/octet-stream\r
-\r
-content of file 1\r
---2256d3a36d2a61a1eba35a22bee5c74a--\r
-"""
-        )
+        assert response.headers == httpx.Headers({"content-length": "14", "x-test": "Test value"})
 
 
 def test_requests_retrieval(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(url="http://test_url", method="GET", data=b"test content 1")
+    httpx_mock.add_response(url="http://test_url", method="GET", content=b"test content 1")
     httpx_mock.add_response(
-        url="http://test_url", method="POST", data=b"test content 2"
+        url="http://test_url", method="POST", content=b"test content 2"
     )
-    httpx_mock.add_response(url="http://test_url", method="PUT", data=b"test content 3")
+    httpx_mock.add_response(url="http://test_url", method="PUT", content=b"test content 3")
     httpx_mock.add_response(
-        url="http://test_url", method="DELETE", data=b"test content 4"
-    )
-    httpx_mock.add_response(
-        url="http://test_url", method="PATCH", data=b"test content 5"
+        url="http://test_url", method="DELETE", content=b"test content 4"
     )
     httpx_mock.add_response(
-        url="http://test_url", method="HEAD", data=b"test content 6"
+        url="http://test_url", method="PATCH", content=b"test content 5"
+    )
+    httpx_mock.add_response(
+        url="http://test_url", method="HEAD", content=b"test content 6"
     )
 
     with httpx.Client() as client:
@@ -625,7 +592,7 @@ def test_callback_raising_exception(httpx_mock: HTTPXMock):
 
 def test_callback_returning_response(httpx_mock: HTTPXMock):
     def custom_response(request: httpx.Request, *args, **kwargs):
-        return to_response(json={"url": str(request.url)})
+        return httpx.Response(status_code=200, json={"url": str(request.url)})
 
     httpx_mock.add_callback(custom_response, url="http://test_url")
 
@@ -637,7 +604,7 @@ def test_callback_returning_response(httpx_mock: HTTPXMock):
 
 def test_callback_executed_twice(httpx_mock: HTTPXMock):
     def custom_response(*args, **kwargs):
-        return to_response(json=["content"])
+        return httpx.Response(status_code=200, json=["content"])
 
     httpx_mock.add_callback(custom_response)
 
@@ -653,7 +620,7 @@ def test_callback_executed_twice(httpx_mock: HTTPXMock):
 
 def test_callback_matching_method(httpx_mock: HTTPXMock):
     def custom_response(*args, **kwargs) -> httpx.Response:
-        return to_response(json=["content"])
+        return httpx.Response(status_code=200, json=["content"])
 
     httpx_mock.add_callback(custom_response, method="GET")
 


### PR DESCRIPTION
Expands upon #49 updating the API to fix #48.

This drops the support for multipart responses and if they need to be added back then there will need to be some adjustments, but it looks like `httpx` has moved their API to discourage that since that is not a common use case (It's more common for the request to be multipart, but the response to not be. I have personally used multipart responses for some things I was doing, but it was always going against the flow to do so and it looks like `httpx` is keeping in line with that)