### PR TITLE
Release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2021-12-20
+### Fixed
+- Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
+
 ## [0.17.0] - 2021-12-20
 ### Changed
 - `httpx_mock.add_response` `data` parameter is only used for multipart content. It was deprecated since `0.14.0`. Refer to this version changelog entry for more details on how to update your code.
@@ -180,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.14.0...v0.15.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-143 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-145 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -227,6 +227,8 @@ class HTTPXMock:
                 # Allow to read the response on client side
                 response.is_stream_consumed = False
                 response.is_closed = False
+                if hasattr(response, "_content"):
+                    del response._content
                 return response
 
         # Or the last registered
@@ -234,6 +236,8 @@ class HTTPXMock:
         # Allow to read the response on client side
         response.is_stream_consumed = False
         response.is_closed = False
+        if hasattr(response, "_content"):
+            del response._content
         return response
 
     def _get_callback(

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1444,3 +1444,12 @@ async def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
         response = await client.get("https://test_url")
 
     assert dict(response.cookies) == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_elapsed(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+    assert response.elapsed is not None

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1343,3 +1343,11 @@ def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
         response = client.get("https://test_url")
 
     assert dict(response.cookies) == {"key": "value"}
+
+
+def test_elapsed(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+    assert response.elapsed is not None


### PR DESCRIPTION
### Fixed
- Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
