### PR TITLE
Release 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2021-12-23
+### Fixed
+- Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
+
 ## [0.17.1] - 2021-12-20
 ### Fixed
 - Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
@@ -184,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...HEAD
+[0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.15.0...v0.16.0

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1447,8 +1447,17 @@ async def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_elapsed(httpx_mock: HTTPXMock) -> None:
+async def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+@pytest.mark.asyncio
+async def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     async with httpx.AsyncClient() as client:
         response = await client.get("https://test_url")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1345,8 +1345,16 @@ def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
     assert dict(response.cookies) == {"key": "value"}
 
 
-def test_elapsed(httpx_mock: HTTPXMock) -> None:
+def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     with httpx.Client() as client:
         response = client.get("https://test_url")


### PR DESCRIPTION
### Fixed
- Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.