### PR TITLE
Release 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] - 2021-12-27
+### Fixed
+- A callback can now raise an exception again (regression in mypy check since [0.16.0]).
+
+### Added
+- An exception can now be raised without creating a callback by using `httpx_mock.add_exception` method.
+
 ## [0.17.2] - 2021-12-23
 ### Fixed
 - Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
@@ -188,7 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.3...HEAD
+[0.17.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2021-12-20
+### Fixed
+- Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
+
 ## [0.17.0] - 2021-12-20
 ### Changed
 - `httpx_mock.add_response` `data` parameter is only used for multipart content. It was deprecated since `0.14.0`. Refer to this version changelog entry for more details on how to update your code.
@@ -180,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.14.0...v0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2021-12-23
+### Fixed
+- Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
+
 ## [0.17.1] - 2021-12-20
 ### Fixed
 - Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
@@ -184,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...HEAD
+[0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.15.0...v0.16.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-143 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-145 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-145 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-151 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -444,7 +444,7 @@ def test_dynamic_response(httpx_mock: HTTPXMock):
 
 ### Raising exceptions
 
-You can simulate HTTPX exception throwing by raising an exception in your callback.
+You can simulate HTTPX exception throwing by raising an exception in your callback or use `httpx_mock.add_exception` with the exception instance.
 
 This can be useful if you want to assert that your code handles HTTPX exceptions properly.
 
@@ -455,10 +455,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_exception_raising(httpx_mock: HTTPXMock):
-    def raise_timeout(request: httpx.Request):
-        raise httpx.ReadTimeout(f"Unable to read within {request.extensions['timeout']['read']}", request=request)
-
-    httpx_mock.add_callback(raise_timeout)
+    httpx_mock.add_exception(httpx.ReadTimeout("Unable to read within timeout"))
     
     with httpx.Client() as client:
         with pytest.raises(httpx.ReadTimeout):

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -227,6 +227,8 @@ class HTTPXMock:
                 # Allow to read the response on client side
                 response.is_stream_consumed = False
                 response.is_closed = False
+                if hasattr(response, "_content"):
+                    del response._content
                 return response
 
         # Or the last registered
@@ -234,6 +236,8 @@ class HTTPXMock:
         # Allow to read the response on client side
         response.is_stream_consumed = False
         response.is_closed = False
+        if hasattr(response, "_content"):
+            del response._content
         return response
 
     def _get_callback(

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1444,3 +1444,12 @@ async def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
         response = await client.get("https://test_url")
 
     assert dict(response.cookies) == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_elapsed(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+    assert response.elapsed is not None

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1447,8 +1447,17 @@ async def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_elapsed(httpx_mock: HTTPXMock) -> None:
+async def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+@pytest.mark.asyncio
+async def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     async with httpx.AsyncClient() as client:
         response = await client.get("https://test_url")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -745,6 +745,29 @@ def test_callback_raising_exception(httpx_mock: HTTPXMock) -> None:
         assert str(exception_info.value) == "Unable to read within 5.0"
 
 
+def test_request_exception_raising(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("Unable to read within 5.0"), url="https://test_url"
+    )
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.ReadTimeout) as exception_info:
+            client.get("https://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
+        assert exception_info.value.request is not None
+
+
+def test_non_request_exception_raising(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        httpx.HTTPError("Unable to read within 5.0"), url="https://test_url"
+    )
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.HTTPError) as exception_info:
+            client.get("https://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
+
+
 def test_callback_returning_response(httpx_mock: HTTPXMock) -> None:
     def custom_response(request: httpx.Request) -> httpx.Response:
         return httpx.Response(status_code=200, json={"url": str(request.url)})
@@ -1354,7 +1377,9 @@ def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
 
 
 def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
+    httpx_mock.add_callback(
+        callback=lambda req: httpx.Response(status_code=200, json={"foo": "bar"})
+    )
 
     with httpx.Client() as client:
         response = client.get("https://test_url")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1343,3 +1343,11 @@ def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
         response = client.get("https://test_url")
 
     assert dict(response.cookies) == {"key": "value"}
+
+
+def test_elapsed(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+    assert response.elapsed is not None

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1345,8 +1345,16 @@ def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
     assert dict(response.cookies) == {"key": "value"}
 
 
-def test_elapsed(httpx_mock: HTTPXMock) -> None:
+def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     with httpx.Client() as client:
         response = client.get("https://test_url")


### PR DESCRIPTION
### Fixed
- A callback can now raise an exception again (regression in mypy check since [0.16.0]).

### Added
- An exception can now be raised without creating a callback by using `httpx_mock.add_exception` method.
