### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] - 2021-12-27
+### Fixed
+- A callback can now raise an exception again (regression in mypy check since [0.16.0]).
+
+### Added
+- An exception can now be raised without creating a callback by using `httpx_mock.add_exception` method.
+
 ## [0.17.2] - 2021-12-23
 ### Fixed
 - Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
@@ -188,7 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.3...HEAD
+[0.17.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Callback are now executed as expected when there is a matching already sent response.
+
+### Changed
+- Registration order is now looking at responses and callbacks. Previous to this version, registration order was looking at responses before callbacks.
 
 ## [0.17.3] - 2021-12-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2021-12-23
+### Fixed
+- Do not consider a callback response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
+
 ## [0.17.1] - 2021-12-20
 ### Fixed
 - Do not consider a response as read, even if it is not a stream, before returning to `httpx`. Allowing any specific httpx handling to be triggered such as `httpx.Response.elapsed` computing.
@@ -184,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...HEAD
+[0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.15.0...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.18.0] - 2022-01-17
 ### Fixed
 - Callback are now executed as expected when there is a matching already sent response.
 
 ### Changed
-- Registration order is now looking at responses and callbacks. Previous to this version, registration order was looking at responses before callbacks.
+- Registration order is now looking at responses and callbacks. Prior to this version, registration order was looking at responses before callbacks.
 
 ### Removed
 - `httpx_mock.add_response` `data`, `files` and `boundary` parameters have been removed. It was deprecated since `0.17.0`. Refer to this version changelog entry for more details on how to update your code.
@@ -203,7 +205,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.3...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.3...v0.18.0
 [0.17.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.0...v0.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Registration order is now looking at responses and callbacks. Previous to this version, registration order was looking at responses before callbacks.
 
+### Removed
+- `httpx_mock.add_response` `data`, `files` and `boundary` parameters have been removed. It was deprecated since `0.17.0`. Refer to this version changelog entry for more details on how to update your code.
+
 ## [0.17.3] - 2021-12-27
 ### Fixed
 - A callback can now raise an exception again (regression in mypy check since [0.16.0]).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Colin Bounouar
+Copyright (c) 2022 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-155 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-153 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-145 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-151 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -444,7 +444,7 @@ def test_dynamic_response(httpx_mock: HTTPXMock):
 
 ### Raising exceptions
 
-You can simulate HTTPX exception throwing by raising an exception in your callback.
+You can simulate HTTPX exception throwing by raising an exception in your callback or use `httpx_mock.add_exception` with the exception instance.
 
 This can be useful if you want to assert that your code handles HTTPX exceptions properly.
 
@@ -455,10 +455,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_exception_raising(httpx_mock: HTTPXMock):
-    def raise_timeout(request: httpx.Request):
-        raise httpx.ReadTimeout(f"Unable to read within {request.extensions['timeout']['read']}", request=request)
-
-    httpx_mock.add_callback(raise_timeout)
+    httpx_mock.add_exception(httpx.ReadTimeout("Unable to read within timeout"))
     
     with httpx.Client() as client:
         with pytest.raises(httpx.ReadTimeout):

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-151 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-155 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -419,6 +419,8 @@ def assert_all_responses_were_requested() -> bool:
     return False
 ```
 
+Note that callbacks are considered as responses, and thus are [selected the same way](#how-response-is-selected).
+
 ### Dynamic responses
 
 Callback should return a `httpx.Response`.
@@ -477,40 +479,6 @@ def test_timeout(httpx_mock: HTTPXMock):
             client.get("https://test_url")
 
 ```
-
-### How callback is selected
-
-In case more than one callback match request, the first one not yet executed (according to the registration order) will be executed.
-
-In case all matching callbacks have been executed, the last one (according to the registration order) will be executed.
-
-You can add criteria so that callback will be sent only in case of a more specific matching.
-
-#### Matching on URL
-
-`url` parameter can either be a string, a python [`re.Pattern`](https://docs.python.org/3/library/re.html) instance or a [`httpx.URL`](https://www.python-httpx.org/api/#url) instance.
-
-Matching is performed on the full URL, query parameters included.
-
-#### Matching on HTTP method
-
-Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) executing the callback.
-
-`method` parameter must be a string. It will be upper-cased, so it can be provided lower cased.
-
-Matching is performed on equality.
-
-#### Matching on HTTP headers
-
-Use `match_headers` parameter to specify the HTTP headers executing the callback.
-
-Matching is performed on equality for each provided header.
-
-#### Matching on HTTP body
-
-Use `match_content` parameter to specify the full HTTP body executing the callback.
-
-Matching is performed on equality.
 
 ## Check sent requests
 

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -4,12 +4,9 @@ from typing import (
     Sequence,
     Tuple,
     Iterable,
-    Optional,
     AsyncIterator,
     Iterator,
-    Any,
 )
-import warnings
 
 import httpx
 
@@ -39,16 +36,3 @@ class IteratorStream(AsyncIteratorByteStream, IteratorByteStream):
 
         AsyncIteratorByteStream.__init__(self, stream=Stream())
         IteratorByteStream.__init__(self, stream=Stream())
-
-
-def multipart_stream(
-    data: dict, files: Any, boundary: Optional[bytes]
-) -> Union[httpx.AsyncByteStream, httpx.SyncByteStream]:
-    warnings.warn(
-        "data, files and boundary parameters will be removed in a future version. Use stream parameter with an instance of httpx._multipart.MultipartStream instead.",
-        DeprecationWarning,
-    )
-    # import is performed at runtime when needed to reduce impact of internal changes in httpx
-    from httpx._multipart import MultipartStream
-
-    return MultipartStream(data=data or {}, files=files, boundary=boundary)

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -102,10 +102,7 @@ class HTTPXMock:
         text: Optional[str] = None,
         html: Optional[str] = None,
         stream: Any = None,
-        data: dict = None,
-        files: Any = None,
         json: Any = None,
-        boundary: bytes = None,
         **matchers,
     ) -> None:
         """
@@ -118,10 +115,7 @@ class HTTPXMock:
         :param text: HTTP body of the response (as string).
         :param html: HTTP body of the response (as HTML string content).
         :param stream: HTTP body of the response (as httpx.SyncByteStream or httpx.AsyncByteStream) as stream content.
-        :param data: HTTP multipart body of the response (as a dictionary) if files is provided.
-        :param files: Multipart files.
         :param json: HTTP body of the response (if JSON should be used as content type) if data is not provided.
-        :param boundary: Multipart boundary if files is provided.
         :param url: Full URL identifying the request(s) to match.
         Can be a str, a re.Pattern instance or a httpx.URL instance.
         :param method: HTTP method identifying the request(s) to match.
@@ -136,11 +130,7 @@ class HTTPXMock:
             content=content,
             text=text,
             html=html,
-            stream=_httpx_internals.multipart_stream(
-                data=data, files=files, boundary=boundary
-            )
-            if files
-            else stream,
+            stream=stream,
         )
         self.add_callback(lambda request: response, **matchers)
 

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.3"
+__version__ = "0.18.0"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Internet :: WWW/HTTP",
         "Framework :: Pytest",

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1447,8 +1447,17 @@ async def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_elapsed(httpx_mock: HTTPXMock) -> None:
+async def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+@pytest.mark.asyncio
+async def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     async with httpx.AsyncClient() as client:
         response = await client.get("https://test_url")

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -573,52 +573,6 @@ async def test_with_headers(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_deprecated_multipart_response(httpx_mock: HTTPXMock) -> None:
-    with pytest.warns(
-        DeprecationWarning,
-        match="data, files and boundary parameters will be removed in a future version. Use stream parameter with an instance of httpx._multipart.MultipartStream instead.",
-    ):
-        httpx_mock.add_response(
-            url="https://test_url",
-            files={"file1": b"content of file 1"},
-            boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-        )
-    with pytest.warns(
-        DeprecationWarning,
-        match="data, files and boundary parameters will be removed in a future version. Use stream parameter with an instance of httpx._multipart.MultipartStream instead.",
-    ):
-        httpx_mock.add_response(
-            url="https://test_url",
-            data={"key1": "value1"},
-            files={"file1": b"content of file 1"},
-            boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-        )
-
-    async with httpx.AsyncClient() as client:
-        response = await client.get("https://test_url")
-        assert (
-            response.text
-            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
-        )
-
-        response = await client.get("https://test_url")
-        assert (
-            response.text
-            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="key1"\r
-\r
-value1\r
---2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="file1"; filename="upload"\r
-Content-Type: application/octet-stream\r
-\r
-content of file 1\r
---2256d3a36d2a61a1eba35a22bee5c74a--\r
-"""
-        )
-
-
-@pytest.mark.asyncio
 async def test_requests_retrieval(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         url="https://test_url", method="GET", content=b"test content 1"

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -745,6 +745,29 @@ def test_callback_raising_exception(httpx_mock: HTTPXMock) -> None:
         assert str(exception_info.value) == "Unable to read within 5.0"
 
 
+def test_request_exception_raising(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        httpx.ReadTimeout("Unable to read within 5.0"), url="https://test_url"
+    )
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.ReadTimeout) as exception_info:
+            client.get("https://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
+        assert exception_info.value.request is not None
+
+
+def test_non_request_exception_raising(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        httpx.HTTPError("Unable to read within 5.0"), url="https://test_url"
+    )
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.HTTPError) as exception_info:
+            client.get("https://test_url")
+        assert str(exception_info.value) == "Unable to read within 5.0"
+
+
 def test_callback_returning_response(httpx_mock: HTTPXMock) -> None:
     def custom_response(request: httpx.Request) -> httpx.Response:
         return httpx.Response(status_code=200, json={"url": str(request.url)})
@@ -1354,7 +1377,9 @@ def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
 
 
 def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
+    httpx_mock.add_callback(
+        callback=lambda req: httpx.Response(status_code=200, json={"foo": "bar"})
+    )
 
     with httpx.Client() as client:
         response = client.get("https://test_url")

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -796,6 +796,50 @@ def test_callback_executed_twice(httpx_mock: HTTPXMock) -> None:
         assert response.headers["content-type"] == "application/json"
 
 
+def test_callback_registered_after_response(httpx_mock: HTTPXMock) -> None:
+    def custom_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json=["content2"])
+
+    httpx_mock.add_response(json=["content1"])
+    httpx_mock.add_callback(custom_response)
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+        assert response.json() == ["content1"]
+        assert response.headers["content-type"] == "application/json"
+
+        response = client.post("https://test_url")
+        assert response.json() == ["content2"]
+        assert response.headers["content-type"] == "application/json"
+
+        # Assert that the last registered callback is sent again even if there is a response
+        response = client.post("https://test_url")
+        assert response.json() == ["content2"]
+        assert response.headers["content-type"] == "application/json"
+
+
+def test_response_registered_after_callback(httpx_mock: HTTPXMock) -> None:
+    def custom_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json=["content1"])
+
+    httpx_mock.add_callback(custom_response)
+    httpx_mock.add_response(json=["content2"])
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+        assert response.json() == ["content1"]
+        assert response.headers["content-type"] == "application/json"
+
+        response = client.post("https://test_url")
+        assert response.json() == ["content2"]
+        assert response.headers["content-type"] == "application/json"
+
+        # Assert that the last registered response is sent again even if there is a callback
+        response = client.post("https://test_url")
+        assert response.json() == ["content2"]
+        assert response.headers["content-type"] == "application/json"
+
+
 def test_callback_matching_method(httpx_mock: HTTPXMock) -> None:
     def custom_response(request: httpx.Request) -> httpx.Response:
         return httpx.Response(status_code=200, json=["content"])

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -516,51 +516,6 @@ def test_with_headers(httpx_mock: HTTPXMock) -> None:
         )
 
 
-def test_deprecated_multipart_response(httpx_mock: HTTPXMock) -> None:
-    with pytest.warns(
-        DeprecationWarning,
-        match="data, files and boundary parameters will be removed in a future version. Use stream parameter with an instance of httpx._multipart.MultipartStream instead.",
-    ):
-        httpx_mock.add_response(
-            url="https://test_url",
-            files={"file1": b"content of file 1"},
-            boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-        )
-    with pytest.warns(
-        DeprecationWarning,
-        match="data, files and boundary parameters will be removed in a future version. Use stream parameter with an instance of httpx._multipart.MultipartStream instead.",
-    ):
-        httpx_mock.add_response(
-            url="https://test_url",
-            data={"key1": "value1"},
-            files={"file1": b"content of file 1"},
-            boundary=b"2256d3a36d2a61a1eba35a22bee5c74a",
-        )
-
-    with httpx.Client() as client:
-        response = client.get("https://test_url")
-        assert (
-            response.text
-            == '--2256d3a36d2a61a1eba35a22bee5c74a\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\ncontent of file 1\r\n--2256d3a36d2a61a1eba35a22bee5c74a--\r\n'
-        )
-
-        response = client.get("https://test_url")
-        assert (
-            response.text
-            == """--2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="key1"\r
-\r
-value1\r
---2256d3a36d2a61a1eba35a22bee5c74a\r
-Content-Disposition: form-data; name="file1"; filename="upload"\r
-Content-Type: application/octet-stream\r
-\r
-content of file 1\r
---2256d3a36d2a61a1eba35a22bee5c74a--\r
-"""
-        )
-
-
 def test_requests_retrieval(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         url="https://test_url", method="GET", content=b"test content 1"

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1345,8 +1345,16 @@ def test_header_as_httpx_headers(httpx_mock: HTTPXMock) -> None:
     assert dict(response.cookies) == {"key": "value"}
 
 
-def test_elapsed(httpx_mock: HTTPXMock) -> None:
+def test_elapsed_when_add_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+    assert response.elapsed is not None
+
+
+def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_callback(callback=lambda req: httpx.Response(status_code=200, json={'foo': 'bar'}))
 
     with httpx.Client() as client:
         response = client.get("https://test_url")


### PR DESCRIPTION
### Fixed
- Callback are now executed as expected when there is a matching already sent response.

### Changed
- Registration order is now looking at responses and callbacks. Prior to this version, registration order was looking at responses before callbacks.

### Removed
- `httpx_mock.add_response` `data`, `files` and `boundary` parameters have been removed. It was deprecated since `0.17.0`. Refer to this version changelog entry for more details on how to update your code.
