### PR TITLE
Support pytest v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
+        pytest-major-version: ['6', '7']
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +20,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install pytest~=${{ matrix.pytest-major-version }}.0
         python -m pip install -e .[testing]
-    - name: Test with pytest
+    - name: Test with pytest v${{ matrix.pytest-major-version }}
       run: |
         pytest --cov=pytest_httpx --cov-fail-under=100 --cov-report=term-missing --runpytest=subprocess

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.22.*", "pytest==6.*"],
+    install_requires=["httpx==0.22.*", "pytest>=6.*"],
     extras_require={
         "testing": [
             # Used to run async test functions


### PR DESCRIPTION
Pytest just released [Pytest v7](https://pypi.org/project/pytest/).  I'm trying to upgrade a project of mine to use it by pytest-httpx has a dependency on `pytest==6.*` which stops me from using v7 in my project.



* Update Github Actions to test against Pytest v6 and v7
* Loosen install requirements to allow v6 and v7

  IMO It's safe to use `pytest>=6.*` as the version specifier as Pytest follow long deprecation periods and don't often break existing code that is widely used, even in major version releases. I'm happy to switch this to `pytest>=6.*,<8.0` if you prefer