### PR TITLE
Release 0.20.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2022-02-05
+### Added
+- Add support for [`pytest`](https://docs.pytest.org)==7.\* ([`pytest`](https://docs.pytest.org)==6.\* is still supported for now).  (many thanks to [`Craig Blaszczyk`](https://github.com/jakul))
+
 ## [0.19.0] - 2022-01-26
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.22.\*
@@ -212,7 +216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.3...v0.18.0
 [0.17.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.17.2...v0.17.3

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
+        "Typing :: Typed",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
@@ -39,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.22.*", "pytest>=6.*"],
+    install_requires=["httpx==0.22.*", "pytest>=6.*,<8.*"],
     extras_require={
         "testing": [
             # Used to run async test functions


### PR DESCRIPTION
### Added
- Add support for [`pytest`](https://docs.pytest.org)==7.\* ([`pytest`](https://docs.pytest.org)==6.\* is still supported for now).  (many thanks to [`Craig Blaszczyk`](https://github.com/jakul))
