### PR TITLE
Changed httpx requirement to 0.23.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.23.\*
 
 ## [0.20.0] - 2022-02-05
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.22.*", "pytest>=6.*,<8.*"],
+    install_requires=["httpx==0.23.*", "pytest>=6.*,<8.*"],
     extras_require={
         "testing": [
             # Used to run async test functions

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -239,18 +239,14 @@ async def test_default_response_streaming(httpx_mock: HTTPXMock) -> None:
 
     async with httpx.AsyncClient() as client:
         async with client.stream(method="GET", url="https://test_url") as response:
-            assert [part async for part in response.aiter_raw()] == [
-                b"",
-            ]
+            assert [part async for part in response.aiter_raw()] == []
             # Assert that stream still behaves the proper way (can only be consumed once per request)
             with pytest.raises(httpx.StreamConsumed):
                 async for part in response.aiter_raw():
                     pass
 
         async with client.stream(method="GET", url="https://test_url") as response:
-            assert [part async for part in response.aiter_raw()] == [
-                b"",
-            ]
+            assert [part async for part in response.aiter_raw()] == []
             # Assert that stream still behaves the proper way (can only be consumed once per request)
             with pytest.raises(httpx.StreamConsumed):
                 async for part in response.aiter_raw():

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -207,14 +207,14 @@ def test_default_response_streaming(httpx_mock: HTTPXMock) -> None:
 
     with httpx.Client() as client:
         with client.stream(method="GET", url="https://test_url") as response:
-            assert list(response.iter_raw()) == [b""]
+            assert list(response.iter_raw()) == []
             # Assert that stream still behaves the proper way (can only be consumed once per request)
             with pytest.raises(httpx.StreamConsumed):
                 list(response.iter_raw())
 
         # Assert a response can be streamed more than once
         with client.stream(method="GET", url="https://test_url") as response:
-            assert list(response.iter_raw()) == [b""]
+            assert list(response.iter_raw()) == []
             # Assert that stream still behaves the proper way (can only be consumed once per request)
             with pytest.raises(httpx.StreamConsumed):
                 list(response.iter_raw())


### PR DESCRIPTION
Hi!

[`httpx`](https://www.python-httpx.org) recently released a new version with an important vulnerability fix. Since pytest-httpx requires version 0.22.x, it's making it impossible to upgrade httpx.

I've thus upgraded the requirement and updated the relevant tests (most behaviour appears to be the same; it's just the streaming tests that needed updating). Since the change in `iter_raw` and `iter_bytes` means pytext-httpx gets a slightly different behaviour between 0.22 and 0.23, I've opted for upgrading to 0.23 rather than changing the requirement to >0.22.x.

This should close #79.