### PR TITLE
Release 0.21.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.21.2] - 2022-11-03
 ### Fixed
 - URL containing non ASCII characters in query can now be matched.
 
@@ -229,7 +231,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.2...HEAD
+[0.21.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.19.0...v0.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- URL containing non ASCII characters in query can now be matched.
 
 ## [0.21.1] - 2022-10-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.21.2] - 2022-11-03
 ### Fixed
 - URL containing non ASCII characters in query can now be matched.
+- Requests are now cleared when calling `httpx_mock.reset`.
 
 ## [0.21.1] - 2022-10-20
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Before creating an issue please make sure that it was not already reported.
 1) Go to the *Pull requests* tab and click on the *New pull request* button.
 2) *base* should always be set to `develop` and it should be compared to your branch.
 3) Title should be a small sentence describing the request.
-3) The comment should contain as much information as possible
+4) The comment should contain as much information as possible
     * Actual behavior (before the new code)
     * Expected behavior (with the new code)
     * Steps to reproduce (with and without the new code to see the difference)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-166 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-168 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-162 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-166 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -300,6 +300,7 @@ class HTTPXMock:
         return requests[0] if requests else None
 
     def reset(self, assert_all_responses_were_requested: bool) -> None:
+        self._requests.clear()
         not_called = self._reset_callbacks()
 
         if assert_all_responses_were_requested:

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -6,9 +6,6 @@ import httpx
 
 from pytest_httpx import _httpx_internals
 
-# re.Pattern was introduced in Python 3.7
-pattern_type = re._pattern_type if hasattr(re, "_pattern_type") else re.Pattern
-
 
 class _RequestMatcher:
     def __init__(
@@ -36,7 +33,7 @@ class _RequestMatcher:
         if not self.url:
             return True
 
-        if isinstance(self.url, pattern_type):
+        if isinstance(self.url, re.Pattern):
             return self.url.match(str(request.url)) is not None
 
         # Compare query parameters apart as order of parameters should not matter

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,7 +1,6 @@
 import inspect
 import re
 from typing import List, Union, Optional, Callable, Tuple, Pattern, Any, Dict, Awaitable
-from urllib.parse import parse_qs
 
 import httpx
 
@@ -41,14 +40,14 @@ class _RequestMatcher:
             return self.url.match(str(request.url)) is not None
 
         # Compare query parameters apart as order of parameters should not matter
-        request_qs = parse_qs(request.url.query)
-        qs = parse_qs(self.url.query)
+        request_params = dict(request.url.params)
+        params = dict(self.url.params)
 
         # Remove the query parameters from the original URL to compare everything besides query parameters
         request_url = request.url.copy_with(query=None)
         url = self.url.copy_with(query=None)
 
-        return (request_qs == qs) and (url == request_url)
+        return (request_params == params) and (url == request_url)
 
     def _method_match(self, request: httpx.Request) -> bool:
         if not self.method:

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
     extras_require={
         "testing": [
             # Used to run async test functions
-            "pytest-asyncio==0.17.*",
+            "pytest-asyncio==0.20.*",
             # Used to check coverage
-            "pytest-cov==3.*",
+            "pytest-cov==4.*",
         ]
     },
     python_requires=">=3.7",

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1669,3 +1669,21 @@ async def test_elapsed_when_add_async_callback(httpx_mock: HTTPXMock) -> None:
     async with httpx.AsyncClient() as client:
         response = await client.get("https://test_url")
     assert response.elapsed is not None
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_url_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url="https://test_url?query_type=数据")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url?query_type=数据")
+    assert response.content == b""
+
+
+@pytest.mark.asyncio
+async def test_url_encoded_matching_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url="https://test_url?a=%E6%95%B0%E6%8D%AE")
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url?a=数据")
+    assert response.content == b""

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1687,3 +1687,15 @@ async def test_url_encoded_matching_response(httpx_mock: HTTPXMock) -> None:
     async with httpx.AsyncClient() as client:
         response = await client.get("https://test_url?a=数据")
     assert response.content == b""
+
+
+@pytest.mark.asyncio
+async def test_reset_is_removing_requests(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+    async with httpx.AsyncClient() as client:
+        await client.get("https://test_url")
+
+    assert len(httpx_mock.get_requests()) == 1
+
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+    assert len(httpx_mock.get_requests()) == 0

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1399,3 +1399,14 @@ def test_url_encoded_matching_response(httpx_mock: HTTPXMock) -> None:
     with httpx.Client() as client:
         response = client.get("https://test_url?a=数据")
     assert response.content == b""
+
+
+def test_reset_is_removing_requests(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+    with httpx.Client() as client:
+        client.get("https://test_url")
+
+    assert len(httpx_mock.get_requests()) == 1
+
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+    assert len(httpx_mock.get_requests()) == 0

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1383,3 +1383,19 @@ def test_elapsed_when_add_callback(httpx_mock: HTTPXMock) -> None:
     with httpx.Client() as client:
         response = client.get("https://test_url")
     assert response.elapsed is not None
+
+
+def test_non_ascii_url_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url="https://test_url?query_type=数据")
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url?query_type=数据")
+    assert response.content == b""
+
+
+def test_url_encoded_matching_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url="https://test_url?a=%E6%95%B0%E6%8D%AE")
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url?a=数据")
+    assert response.content == b""


### PR DESCRIPTION
### Fixed
- URL containing non ASCII characters in query can now be matched.
- Requests are now cleared when calling `httpx_mock.reset`.

fixes #82
fixes #87 