### PR TITLE
Update version specifiers for pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.3] - 2023-01-19
+- Update version specifiers for pytest dependency to support Packaging 23.0
+
 ## [0.21.2] - 2022-11-03
 ### Fixed
 - URL containing non ASCII characters in query can now be matched.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.23.*", "pytest>=6.*,<8.*"],
+    install_requires=["httpx==0.23.*", "pytest>=6.0,<8.0"],
     extras_require={
         "testing": [
             # Used to run async test functions


### PR DESCRIPTION
Python packaging 23.0 removes the ability to use inequalities with specifiers containing `*`. This means that projects that depend on this library fail to build if using an updated build tooling.

See the following:
- https://github.com/pdm-project/pdm/issues/1596
- https://github.com/pdm-project/pdm/issues/1619
- https://github.com/mkaranasou/pyaml_env/issues/30