### PR TITLE
Include CHANGELOG and tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CHANGELOG.md
+recursive-include tests *.py


### PR DESCRIPTION
Include `CHANGELOG.md` and `tests` directory in generated sdist archives.  This will help Linux distributions and Conda to package pytest-httpx without having to resort to generated GitHub snapshots.