### PR TITLE
Release 0.23.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         pytest-major-version: ['6', '7']
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.7.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.23.0] - 2023-08-02
 ### Removed
 - Python `3.7` and `3.8` are no longer supported.
 
@@ -246,7 +248,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.3...v0.22.0
 [0.21.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.1...v0.21.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Python `3.7` and `3.8` are no longer supported.
 
 ## [0.22.0] - 2023-04-12
 ### Changed
@@ -29,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires [`httpx`](https://www.python-httpx.org)==0.23.\*
 
 ### Removed
-- Python 3.6 is no longer supported.
+- Python `3.6` is no longer supported.
 
 ## [0.20.0] - 2022-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Python `3.7` and `3.8` are no longer supported.
 
+### Fixed
+- `httpx_mock.add_response` is now returning a new `httpx.Response` instance upon each matching request. Preventing unnecessary cascading streams.
+
 ## [0.22.0] - 2023-04-12
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.24.\*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CHANGELOG.md
+recursive-include tests *.py

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from typing import List
 
 import httpx
@@ -34,7 +35,7 @@ def httpx_mock(
     monkeypatch: MonkeyPatch,
     assert_all_responses_were_requested: bool,
     non_mocked_hosts: List[str],
-) -> HTTPXMock:
+) -> Generator[HTTPXMock, None, None]:
     # Ensure redirections to www hosts are handled transparently.
     missing_www = [
         f"www.{host}" for host in non_mocked_hosts if not host.startswith("www.")

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -124,17 +124,20 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         """
-        response = httpx.Response(
-            status_code=status_code,
-            extensions={"http_version": http_version.encode("ascii")},
-            headers=headers,
-            json=json,
-            content=content,
-            text=text,
-            html=html,
-            stream=stream,
-        )
-        self.add_callback(lambda request: response, **matchers)
+
+        def response_callback(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                status_code=status_code,
+                extensions={"http_version": http_version.encode("ascii")},
+                headers=headers,
+                json=json,
+                content=content,
+                text=text,
+                html=html,
+                stream=stream,
+            )
+
+        self.add_callback(response_callback, **matchers)
 
     def add_callback(
         self,

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         "testing": [
             # Used to run async test functions
-            "pytest-asyncio==0.20.*",
+            "pytest-asyncio==0.21.*",
             # Used to check coverage
             "pytest-cov==4.*",
         ]

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ setup(
         "Typing :: Typed",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -50,7 +48,7 @@ setup(
             "pytest-cov==4.*",
         ]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     project_urls={
         "GitHub": "https://github.com/Colin-b/pytest_httpx",
         "Changelog": "https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md",


### PR DESCRIPTION
### Removed
- Python `3.7` and `3.8` are no longer supported.

### Fixed
- `httpx_mock.add_response` is now returning a new `httpx.Response` instance upon each matching request. Preventing unnecessary cascading streams.

Closes #99 