### PR TITLE
Release 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.23.1] - 2023-08-02
 ### Fixed
 - Version `0.23.0` introduced a regression removing the support for mutating json content provided in `httpx_mock.add_response`. 
   - This is fixed, you can now expect the JSON return being as it was when provided to `httpx_mock.add_response`:
@@ -260,7 +262,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.3...v0.22.0
 [0.21.3]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.2...v0.21.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python `3.7` and `3.8` are no longer supported.
 
 ### Fixed
-- `httpx_mock.add_response` is now returning a new `httpx.Response` instance upon each matching request. Preventing unnecessary cascading streams.
+- `httpx_mock.add_response` is now returning a new `httpx.Response` instance upon each matching request. Preventing unnecessary recursion in streams.
 
 ## [0.22.0] - 2023-04-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Version `0.23.0` introduced a regression removing the support for mutating json content provided in `httpx_mock.add_response`. 
+  - This is fixed, you can now expect the JSON return being as it was when provided to `httpx_mock.add_response`:
+```python
+    mutating_json = {"content": "request 1"}
+    # This will return {"content": "request 1"}
+    httpx_mock.add_response(json=mutating_json)
+
+    mutating_json["content"] = "request 2"
+    # This will return {"content": "request 2"}
+    httpx_mock.add_response(json=mutating_json)
+```
 
 ## [0.23.0] - 2023-08-02
 ### Removed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-168 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-169 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-169 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-171 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import re
 from typing import List, Union, Optional, Callable, Tuple, Pattern, Any, Dict, Awaitable
@@ -124,6 +125,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         """
+
+        json = copy.deepcopy(json) if json is not None else None
 
         def response_callback(request: httpx.Request) -> httpx.Response:
             return httpx.Response(

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1699,3 +1699,14 @@ async def test_reset_is_removing_requests(httpx_mock: HTTPXMock) -> None:
 
     httpx_mock.reset(assert_all_responses_were_requested=False)
     assert len(httpx_mock.get_requests()) == 0
+
+
+@pytest.mark.asyncio
+async def test_streams_are_not_cascading_resulting_in_maximum_recursion(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(json={"abc": "def"})
+    async with httpx.AsyncClient() as client:
+        tasks = [client.get("https://example.com/") for _ in range(950)]
+        await asyncio.gather(*tasks)
+    # No need to assert anything, this test case ensure that no error was raised by the gather

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1702,6 +1702,22 @@ async def test_reset_is_removing_requests(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
+async def test_mutating_json(httpx_mock: HTTPXMock) -> None:
+    mutating_json = {"content": "request 1"}
+    httpx_mock.add_response(json=mutating_json)
+
+    mutating_json["content"] = "request 2"
+    httpx_mock.add_response(json=mutating_json)
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://test_url")
+        assert response.json() == {"content": "request 1"}
+
+        response = await client.get("https://test_url")
+        assert response.json() == {"content": "request 2"}
+
+
+@pytest.mark.asyncio
 async def test_streams_are_not_cascading_resulting_in_maximum_recursion(
     httpx_mock: HTTPXMock,
 ) -> None:

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1410,3 +1410,18 @@ def test_reset_is_removing_requests(httpx_mock: HTTPXMock) -> None:
 
     httpx_mock.reset(assert_all_responses_were_requested=False)
     assert len(httpx_mock.get_requests()) == 0
+
+
+def test_mutating_json(httpx_mock: HTTPXMock) -> None:
+    mutating_json = {"content": "request 1"}
+    httpx_mock.add_response(json=mutating_json)
+
+    mutating_json["content"] = "request 2"
+    httpx_mock.add_response(json=mutating_json)
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url")
+        assert response.json() == {"content": "request 1"}
+
+        response = client.get("https://test_url")
+        assert response.json() == {"content": "request 2"}


### PR DESCRIPTION
### Fixed
- Version `0.23.0` introduced a regression removing the support for mutating json content provided in `httpx_mock.add_response`. 
  - This is fixed, you can now expect the JSON return being as it was when provided to `httpx_mock.add_response`:
```python
    mutating_json = {"content": "request 1"}
    # This will return {"content": "request 1"}
    httpx_mock.add_response(json=mutating_json)

    mutating_json["content"] = "request 2"
    # This will return {"content": "request 2"}
    httpx_mock.add_response(json=mutating_json)
```