### PR TITLE
Added the match_json_content matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `match_json_content` which allows matching a json decoded body against an arbitrary python object for equality.
 
 ## [0.23.1] - 2023-08-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `match_json_content` which allows matching a json decoded body against an arbitrary python object for equality.
+- Added `match_json` which allows matching a json decoded body against an arbitrary python object for equality.
 
 ### Changed
 - Even if it was never documented as a feature, the `match_headers` parameter was not considering header names case when matching.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ def test_content_matching(httpx_mock: HTTPXMock):
 
 #### Matching on HTTP json body
 
-Use `match_json_content` parameter to specify the json that will be matched with the json decoded HTTP body to reply to.
+Use `match_json` parameter to specify the json that will be matched with the json decoded HTTP body to reply to.
+Only one of `match_json` and `match_content` should be used. 
 
 Maching is performed on equality after json decoding the body.
 
@@ -193,7 +194,7 @@ import httpx
 from pytest_httpx import HTTPXMock
 
 def test_json_matching(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(match_json_content={"a": "json", "b": 2})
+    httpx_mock.add_response(match_json={"a": "json", "b": 2})
 
     with httpx.Client() as client:
         response = client.post("https://test_url", json={"a": "json", "b": 2})

--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ def test_content_matching(httpx_mock: HTTPXMock):
         response = client.post("https://test_url", content=b"This is the body")
 ```
 
+#### Matching on HTTP json body
+
+Use `match_json_content` parameter to specify the json that will be matched with the json decoded HTTP body to reply to.
+
+Maching is performed on equality after json decoding the body.
+
+```python
+import httpx
+from pytest_httpx import HTTPXMock
+
+def test_json_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(match_json_content={"a": "json", "b": 2})
+
+    with httpx.Client() as client:
+        response = client.post("https://test_url", json={"a": "json", "b": 2})
+```
+        
+
 ### Add JSON response
 
 Use `json` parameter to add a JSON response using python values.

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -16,7 +16,7 @@ class _RequestMatcher:
         method: Optional[str] = None,
         match_headers: Optional[Dict[str, Any]] = None,
         match_content: Optional[bytes] = None,
-        match_json_content: Optional[Union[dict[str, Any], str, float, int]] = None,
+        match_json_content: Optional[Any] = None,
     ):
         self.nb_calls = 0
         self.url = httpx.URL(url) if url and isinstance(url, str) else url

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -256,6 +256,8 @@ class HTTPXMock:
             request_description += f" with {dict({name: value for name, value in request.headers.items() if name in expect_headers})} headers"
             if expect_body:
                 request_description += f" and {request.read()} body"
+            elif expect_json:
+                request_description += f" and {request.read().decode('utf-8')} body"
         elif expect_body:
             request_description += f" with {request.read()} body"
         elif expect_json:

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1252,7 +1252,7 @@ async def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None
 
 
 @pytest.mark.asyncio
-async def test_match_json_matching(httpx_mock: HTTPXMock) -> None:
+async def test_json_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:
@@ -1261,7 +1261,7 @@ async def test_match_json_matching(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
+async def test_json_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:
@@ -1278,7 +1278,7 @@ Match all requests with {'a': 1, 'b': 2} json body"""
 
 
 @pytest.mark.asyncio
-async def test_headers_and_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
+async def test_headers_and_json_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         match_json={"a": 1, "b": 2},
         match_headers={"foo": "bar"},
@@ -1298,7 +1298,7 @@ Match all requests with {'foo': 'bar'} headers and {'a': 1, 'b': 2} json body"""
 
 
 @pytest.mark.asyncio
-async def test_match_json_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
+async def test_match_json_invalid_json(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1246,8 +1246,14 @@ Match all requests with b'This is the body' body"""
 
 
 @pytest.mark.asyncio
-async def test_json_content_matching(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content={"a": 1, "b": 2})
+async def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None:
+    with pytest.raises(ValueError):
+        httpx_mock.add_response(match_json={"a": 1}, match_content=b"<foo></bar/>")
+
+
+@pytest.mark.asyncio
+async def test_match_json_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:
         response = await client.post("https://test_url", json={"b": 2, "a": 1})
@@ -1255,15 +1261,15 @@ async def test_json_content_matching(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_json_content_not_matching(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content={"a": 1, "b": 2})
+async def test_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
             await client.post("https://test_url", json={"c": 3, "b": 2, "a": 1})
         assert (
             str(exception_info.value)
-            == """No response can be found for POST request on https://test_url with {"c": 3, "b": 2, "a": 1} body amongst:
+            == """No response can be found for POST request on https://test_url with b'{"c": 3, "b": 2, "a": 1}' body amongst:
 Match all requests with {'a': 1, 'b': 2} json body"""
         )
 
@@ -1272,9 +1278,9 @@ Match all requests with {'a': 1, 'b': 2} json body"""
 
 
 @pytest.mark.asyncio
-async def test_headers_and_json_content_not_matching(httpx_mock: HTTPXMock) -> None:
+async def test_headers_and_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
-        match_json_content={"a": 1, "b": 2},
+        match_json={"a": 1, "b": 2},
         match_headers={"foo": "bar"},
     )
 
@@ -1283,7 +1289,7 @@ async def test_headers_and_json_content_not_matching(httpx_mock: HTTPXMock) -> N
             await client.post("https://test_url", json={"c": 3, "b": 2, "a": 1})
         assert (
             str(exception_info.value)
-            == """No response can be found for POST request on https://test_url with {} headers and {"c": 3, "b": 2, "a": 1} body amongst:
+            == """No response can be found for POST request on https://test_url with {} headers and b'{"c": 3, "b": 2, "a": 1}' body amongst:
 Match all requests with {'foo': 'bar'} headers and {'a': 1, 'b': 2} json body"""
         )
 
@@ -1292,15 +1298,15 @@ Match all requests with {'foo': 'bar'} headers and {'a': 1, 'b': 2} json body"""
 
 
 @pytest.mark.asyncio
-async def test_json_content_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content={"a": 1, "b": 2})
+async def test_match_json_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     async with httpx.AsyncClient() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
             await client.post("https://test_url", content=b"<test>foobar</test>")
         assert (
             str(exception_info.value)
-            == """No response can be found for POST request on https://test_url with <test>foobar</test> body amongst:
+            == """No response can be found for POST request on https://test_url with b'<test>foobar</test>' body amongst:
 Match all requests with {'a': 1, 'b': 2} json body"""
         )
 

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -998,7 +998,7 @@ def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.parametrize("json", [{"a": 1, "b": 2}, "somestring", "25", 25.3])
-def test_match_json_matching(json: Any, httpx_mock: HTTPXMock) -> None:
+def test_json_matching(json: Any, httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json=json)
 
     with httpx.Client() as client:
@@ -1006,7 +1006,7 @@ def test_match_json_matching(json: Any, httpx_mock: HTTPXMock) -> None:
         assert response.read() == b""
 
 
-def test_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
+def test_json_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     with httpx.Client() as client:
@@ -1022,7 +1022,7 @@ Match all requests with {'a': 1, 'b': 2} json body"""
     httpx_mock.reset(assert_all_responses_were_requested=False)
 
 
-def test_match_json_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
+def test_json_invalid_json(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     with httpx.Client() as client:

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -992,24 +992,29 @@ Match all requests with b'This is the body' body"""
     httpx_mock.reset(assert_all_responses_were_requested=False)
 
 
+def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None:
+    with pytest.raises(ValueError):
+        httpx_mock.add_response(match_json={"a": 1}, match_content=b"<foo></bar/>")
+
+
 @pytest.mark.parametrize("json", [{"a": 1, "b": 2}, "somestring", "25", 25.3])
-def test_json_content_matching(json: Any, httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content=json)
+def test_match_json_matching(json: Any, httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json=json)
 
     with httpx.Client() as client:
         response = client.post("https://test_url", json=json)
         assert response.read() == b""
 
 
-def test_json_content_not_matching(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content={"a": 1, "b": 2})
+def test_match_json_not_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     with httpx.Client() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
             client.post("https://test_url", json={"c": 3, "b": 2, "a": 1})
         assert (
             str(exception_info.value)
-            == """No response can be found for POST request on https://test_url with {"c": 3, "b": 2, "a": 1} body amongst:
+            == """No response can be found for POST request on https://test_url with b'{"c": 3, "b": 2, "a": 1}' body amongst:
 Match all requests with {'a': 1, 'b': 2} json body"""
         )
 
@@ -1017,15 +1022,15 @@ Match all requests with {'a': 1, 'b': 2} json body"""
     httpx_mock.reset(assert_all_responses_were_requested=False)
 
 
-def test_json_content_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(match_json_content={"a": 1, "b": 2})
+def test_match_json_not_matching_invalid_json(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": 2})
 
     with httpx.Client() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
             client.post("https://test_url", content=b"<test>foobar</test>")
         assert (
             str(exception_info.value)
-            == """No response can be found for POST request on https://test_url with <test>foobar</test> body amongst:
+            == """No response can be found for POST request on https://test_url with b'<test>foobar</test>' body amongst:
 Match all requests with {'a': 1, 'b': 2} json body"""
         )
 


### PR DESCRIPTION
closes #83 
Added the match_json_content matcher which checks if the passed object matches the json decoded request body

I preferred adding a new matcher `match_json_content` over modifying the existing `match_content`.

I could have added conditions that if the `match_content` argument isn't of type `bytes` then assume we want to json decode the body, but that doesn't match nicely with [Explicit is better than implicit.](https://peps.python.org/pep-0020/), and with the extra argument I think the code also stays cleaner. 