### PR TITLE
Add Any type to **matchers argument to statisfy strict type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Add `:Any` type hint to `**matchers` function arguments to satisfy strict type checking mode in pyright
 
 ## [0.23.1] - 2023-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add `:Any` type hint to `**matchers` function arguments to satisfy strict type checking mode in pyright
 
 ## [0.23.1] - 2023-08-02
 ### Fixed

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -106,7 +106,7 @@ class HTTPXMock:
         html: Optional[str] = None,
         stream: Any = None,
         json: Any = None,
-        **matchers,
+        **matchers: Any,
     ) -> None:
         """
         Mock the response that will be sent if a request match.
@@ -148,7 +148,7 @@ class HTTPXMock:
             [httpx.Request],
             Union[Optional[httpx.Response], Awaitable[Optional[httpx.Response]]],
         ],
-        **matchers,
+        **matchers: Any,
     ) -> None:
         """
         Mock the action that will take place if a request match.
@@ -163,7 +163,7 @@ class HTTPXMock:
         """
         self._callbacks.append((_RequestMatcher(**matchers), callback))
 
-    def add_exception(self, exception: Exception, **matchers) -> None:
+    def add_exception(self, exception: Exception, **matchers: Any) -> None:
         """
         Raise an exception if a request match.
 
@@ -275,7 +275,7 @@ class HTTPXMock:
         matcher.nb_calls += 1
         return callback
 
-    def get_requests(self, **matchers) -> List[httpx.Request]:
+    def get_requests(self, **matchers: Any) -> List[httpx.Request]:
         """
         Return all requests sent that match (empty list if no requests were matched).
 
@@ -288,7 +288,7 @@ class HTTPXMock:
         matcher = _RequestMatcher(**matchers)
         return [request for request in self._requests if matcher.match(request)]
 
-    def get_request(self, **matchers) -> Optional[httpx.Request]:
+    def get_request(self, **matchers: Any) -> Optional[httpx.Request]:
         """
         Return the single request that match (or None).
 


### PR DESCRIPTION
closes #104 

Adding `:Any` type hint to `**matchers` arguments. This is to satisfy pyrights strict type checking mode.