### PR TITLE
Make sure the match_headers errors are displayed correctly for lower cased version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- If httpx lower cases a header name (like authorization) make sure the header is still displayed in the error if another parameter doesn't match
+
 
 ## [0.23.1] - 2023-08-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- If httpx lower cases a header name (like authorization) make sure the header is still displayed in the error if another parameter doesn't match
+- If `httpx` lower cases a header name (like authorization), make sure the header is still displayed in the error if another parameter doesn't match.
 - Add `:Any` type hint to `**matchers` function arguments to satisfy strict type checking mode in pyright
 
 ## [0.23.1] - 2023-08-02

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -232,11 +232,11 @@ class HTTPXMock:
 
         request_description = f"{request.method} request on {request.url}"
         if expect_headers:
-            present_headers = dict(
-                (name, request.headers.get(name))
+            present_headers = {
+                name: request.headers.get(name)
                 for name in expect_headers
                 if request.headers.get(name) is not None
-            )
+            }
             request_description += f" with {present_headers} headers"
             if expect_body:
                 request_description += f" and {request.read()} body"

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -232,7 +232,12 @@ class HTTPXMock:
 
         request_description = f"{request.method} request on {request.url}"
         if expect_headers:
-            request_description += f" with {dict({name: value for name, value in request.headers.items() if name in expect_headers})} headers"
+            present_headers = dict(
+                (name, request.headers.get(name))
+                for name in expect_headers
+                if request.headers.get(name) is not None
+            )
+            request_description += f" with {present_headers} headers"
             if expect_body:
                 request_description += f" and {request.read()} body"
         elif expect_body:

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1117,6 +1117,28 @@ Match all requests with {{'user-agent': 'python-httpx/{httpx.__version__}', 'hos
 
 
 @pytest.mark.asyncio
+async def test_url_not_matching_authorizaiton_headers_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="http://test_url?q=b",
+        match_headers={"Authorization": "Bearer: Something"},
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.TimeoutException) as exception_info:
+            await client.get(
+                "http://test_url", headers={"Authorization": "Bearer: Something"}
+            )
+        assert (
+            str(exception_info.value)
+            == """No response can be found for GET request on http://test_url with {'Authorization': 'Bearer: Something'} headers amongst:
+Match GET requests on http://test_url?q=b with {'Authorization': 'Bearer: Something'} headers"""
+        )
+
+    # Clean up responses to avoid assertion failure
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+
+@pytest.mark.asyncio
 async def test_content_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_content=b"This is the body")
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1117,21 +1117,19 @@ Match all requests with {{'user-agent': 'python-httpx/{httpx.__version__}', 'hos
 
 
 @pytest.mark.asyncio
-async def test_url_not_matching_authorizaiton_headers_matching(httpx_mock: HTTPXMock):
+async def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET",
-        url="http://test_url?q=b",
-        match_headers={"Authorization": "Bearer: Something"},
+        url="https://test_url?q=b",
+        match_headers={"MyHeader": "Something"},
     )
     async with httpx.AsyncClient() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
-            await client.get(
-                "http://test_url", headers={"Authorization": "Bearer: Something"}
-            )
+            await client.get("https://test_url", headers={"MyHeader": "Something"})
         assert (
             str(exception_info.value)
-            == """No response can be found for GET request on http://test_url with {'Authorization': 'Bearer: Something'} headers amongst:
-Match GET requests on http://test_url?q=b with {'Authorization': 'Bearer: Something'} headers"""
+            == """No response can be found for GET request on https://test_url with {'MyHeader': 'Something'} headers amongst:
+Match GET requests on https://test_url?q=b with {'MyHeader': 'Something'} headers"""
         )
 
     # Clean up responses to avoid assertion failure

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1117,7 +1117,7 @@ Match all requests with {{'user-agent': 'python-httpx/{httpx.__version__}', 'hos
 
 
 @pytest.mark.asyncio
-async def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock):
+async def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="GET",
         url="https://test_url?q=b",

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -139,21 +139,19 @@ def test_response_with_html_string_body(httpx_mock: HTTPXMock) -> None:
         assert response.text == "<body>test content</body>"
 
 
-def test_url_not_matching_authorizaiton_headers_matching(httpx_mock: HTTPXMock):
+def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET",
-        url="http://test_url?q=b",
-        match_headers={"Authorization": "Bearer: Something"},
+        url="https://test_url?q=b",
+        match_headers={"MyHeader": "Something"},
     )
     with httpx.Client() as client:
         with pytest.raises(httpx.TimeoutException) as exception_info:
-            client.get(
-                "http://test_url", headers={"Authorization": "Bearer: Something"}
-            )
+            client.get("https://test_url", headers={"MyHeader": "Something"})
         assert (
             str(exception_info.value)
-            == """No response can be found for GET request on http://test_url with {'Authorization': 'Bearer: Something'} headers amongst:
-Match GET requests on http://test_url?q=b with {'Authorization': 'Bearer: Something'} headers"""
+            == """No response can be found for GET request on https://test_url with {'MyHeader': 'Something'} headers amongst:
+Match GET requests on https://test_url?q=b with {'MyHeader': 'Something'} headers"""
         )
 
     # Clean up responses to avoid assertion failure

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -139,7 +139,7 @@ def test_response_with_html_string_body(httpx_mock: HTTPXMock) -> None:
         assert response.text == "<body>test content</body>"
 
 
-def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock):
+def test_url_not_matching_upper_case_headers_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="GET",
         url="https://test_url?q=b",


### PR DESCRIPTION
closes #106 

Make sure we still display the original header name and value in errors if httpx converted a header name to lower case, and another parameter doesn't match. 

So we display
```python
httpx.TimeoutException: No response can be found for GET request on http://www.google.com with {'MyHeader': 'Something'} headers amongst:
E       Match GET requests on http://www.google.com?q=b with {'MyHeader': 'Something'} headers
```
instead of 
```python
httpx.TimeoutException: No response can be found for GET request on http://www.google.com with {} headers amongst:
E       Match GET requests on http://www.google.com?q=b with {'MyHeader': 'Something'} headers
```
with this test:
```python
from pytest_httpx import HTTPXMock
import httpx


def test_something(httpx_mock: HTTPXMock):
    httpx_mock.add_response(
        method="GET",
        url="http://www.google.com?q=b",
        match_headers={"MyHeader": "Something"},
    )
    with httpx.Client() as client:
        client.get(
            "http://www.google.com", headers={"MyHeader": "Something"}
        )
```