### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `match_json` which allows matching a json decoded body against an arbitrary python object for equality.
+- Added `match_json` parameter which allows matching on JSON decoded body (matching against python representation instead of bytes).
 
 ### Changed
 - Even if it was never documented as a feature, the `match_headers` parameter was not considering header names case when matching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.24.0] - 2023-09-04
 ### Added
 - Added `match_json` parameter which allows matching on JSON decoded body (matching against python representation instead of bytes).
 
@@ -274,7 +276,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.21.3...v0.22.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-190 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-192 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -186,14 +186,22 @@ def test_content_matching(httpx_mock: HTTPXMock):
 
 Use `match_json` parameter to specify the JSON decoded HTTP body to reply to.
 
-Matching is performed on equality.
+Matching is performed on equality. You can however use `unittest.mock.ANY` to do partial matching.
 
 ```python
 import httpx
 from pytest_httpx import HTTPXMock
+from unittest.mock import ANY
 
 def test_json_matching(httpx_mock: HTTPXMock):
     httpx_mock.add_response(match_json={"a": "json", "b": 2})
+
+    with httpx.Client() as client:
+        response = client.post("https://test_url", json={"a": "json", "b": 2})
+
+        
+def test_partial_json_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(match_json={"a": "json", "b": ANY})
 
     with httpx.Client() as client:
         response = client.post("https://test_url", json={"a": "json", "b": 2})

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-181 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-190 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -182,12 +182,11 @@ def test_content_matching(httpx_mock: HTTPXMock):
         response = client.post("https://test_url", content=b"This is the body")
 ```
 
-#### Matching on HTTP json body
+##### Matching on HTTP JSON body
 
-Use `match_json` parameter to specify the json that will be matched with the json decoded HTTP body to reply to.
-Only one of `match_json` and `match_content` should be used. 
+Use `match_json` parameter to specify the JSON decoded HTTP body to reply to.
 
-Maching is performed on equality after json decoding the body.
+Matching is performed on equality.
 
 ```python
 import httpx
@@ -200,6 +199,7 @@ def test_json_matching(httpx_mock: HTTPXMock):
         response = client.post("https://test_url", json={"a": "json", "b": 2})
 ```
         
+Note that `match_content` cannot be provided if `match_json` is also provided.
 
 ### Add JSON response
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -24,7 +24,7 @@ class _RequestMatcher:
         self.headers = match_headers
         if match_content is not None and match_json is not None:
             raise ValueError(
-                "Only one parameter of match_json or match_content can be supplied."
+                "Only one way of matching against the body can be provided. If you want to match against the JSON decoded representation, use match_json. Otherwise, use match_content."
             )
         self.content = match_content
         self.json = match_json
@@ -150,7 +150,7 @@ class HTTPXMock:
         :param method: HTTP method identifying the request(s) to match.
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
-        :param match_json: Any object that should match json.loads(request.body.decode(encoding))
+        :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
         """
 
         json = copy.deepcopy(json) if json is not None else None
@@ -187,7 +187,7 @@ class HTTPXMock:
         :param method: HTTP method identifying the request(s) to match.
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
-        :param match_json: Any object that should match json.loads(request.body.decode(encoding))
+        :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
         """
         self._callbacks.append((_RequestMatcher(**matchers), callback))
 
@@ -201,7 +201,7 @@ class HTTPXMock:
         :param method: HTTP method identifying the request(s) to match.
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
-        :param match_json: Any object that should match json.loads(request.body.decode(encoding))
+        :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
         """
 
         def exception_callback(request: httpx.Request) -> None:
@@ -327,9 +327,10 @@ class HTTPXMock:
 
         :param url: Full URL identifying the requests to retrieve.
         Can be a str, a re.Pattern instance or a httpx.URL instance.
-        :param method: HTTP method identifying the requests to retrieve. Must be a upper cased string value.
+        :param method: HTTP method identifying the requests to retrieve. Must be an upper-cased string value.
         :param match_headers: HTTP headers identifying the requests to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the requests to retrieve. Must be bytes.
+        :param match_json: JSON decoded HTTP body identifying the requests to retrieve. Must be JSON encodable.
         """
         matcher = _RequestMatcher(**matchers)
         return [request for request in self._requests if matcher.match(request)]
@@ -340,9 +341,10 @@ class HTTPXMock:
 
         :param url: Full URL identifying the request to retrieve.
         Can be a str, a re.Pattern instance or a httpx.URL instance.
-        :param method: HTTP method identifying the request to retrieve. Must be a upper cased string value.
+        :param method: HTTP method identifying the request to retrieve. Must be an upper-cased string value.
         :param match_headers: HTTP headers identifying the request to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request to retrieve. Must be bytes.
+        :param match_json: JSON decoded HTTP body identifying the request to retrieve. Must be JSON encodable.
         :raises AssertionError: in case more than one request match.
         """
         requests = self.get_requests(**matchers)

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.23.1"
+__version__ = "0.24.0"

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -6,6 +6,7 @@ import time
 import httpx
 import pytest
 from pytest import Testdir
+from unittest.mock import ANY
 
 import pytest_httpx
 from pytest_httpx import HTTPXMock
@@ -1248,6 +1249,15 @@ Match all requests with b'This is the body' body"""
 @pytest.mark.asyncio
 async def test_json_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("https://test_url", json={"b": 2, "a": 1})
+        assert response.read() == b""
+
+
+@pytest.mark.asyncio
+async def test_json_partial_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": ANY})
 
     async with httpx.AsyncClient() as client:
         response = await client.post("https://test_url", json={"b": 2, "a": 1})

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1246,12 +1246,6 @@ Match all requests with b'This is the body' body"""
 
 
 @pytest.mark.asyncio
-async def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None:
-    with pytest.raises(ValueError):
-        httpx_mock.add_response(match_json={"a": 1}, match_content=b"<foo></bar/>")
-
-
-@pytest.mark.asyncio
 async def test_json_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
 

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1,5 +1,6 @@
 import re
 from typing import Any
+from unittest.mock import ANY
 
 import httpx
 import pytest
@@ -1004,6 +1005,14 @@ def test_match_json_and_match_content_error(httpx_mock: HTTPXMock) -> None:
 
 def test_json_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_json={"a": 1, "b": 2})
+
+    with httpx.Client() as client:
+        response = client.post("https://test_url", json={"b": 2, "a": 1})
+        assert response.read() == b""
+
+
+def test_json_partial_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_json={"a": 1, "b": ANY})
 
     with httpx.Client() as client:
         response = client.post("https://test_url", json={"b": 2, "a": 1})


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.25.\*

### Removed
- `pytest` `6` is no longer supported.