### PR TITLE
Support Python >= 3.8, <3.12 & httpx >= 0.23.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
+        httpx-version: ['0.25.0', '0.24.1', '0.23.3']
 
     steps:
     - uses: actions/checkout@v4
@@ -19,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install httpx==${{ matrix.httpx-version }}
         python -m pip install -e .[testing]
     - name: Test
       run: |

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,5 +1,4 @@
-from collections.abc import Generator
-from typing import List
+from typing import List, Generator
 
 import httpx
 import pytest

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -7,7 +7,7 @@ from typing import (
     Iterable,
     AsyncIterator,
     Iterator,
-    Optional,
+    Optional, List,
 )
 
 import httpcore
@@ -41,7 +41,7 @@ class IteratorStream(AsyncIteratorByteStream, IteratorByteStream):
         IteratorByteStream.__init__(self, stream=Stream())
 
 
-def _to_httpx_url(url: httpcore.URL, headers: list[tuple[bytes, bytes]]) -> httpx.URL:
+def _to_httpx_url(url: httpcore.URL, headers: List[Tuple[bytes, bytes]]) -> httpx.URL:
     for name, value in headers:
         if b"Proxy-Authorization" == name:
             return httpx.URL(

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,6 +1,6 @@
 import copy
 import inspect
-from typing import Union, Optional, Callable, Any, Awaitable
+from typing import Union, Optional, Callable, Any, Awaitable, List
 
 import httpx
 
@@ -207,7 +207,7 @@ class HTTPXMock:
         matcher.nb_calls += 1
         return callback
 
-    def get_requests(self, **matchers: Any) -> list[httpx.Request]:
+    def get_requests(self, **matchers: Any) -> List[httpx.Request]:
         """
         Return all requests sent that match (empty list if no requests were matched).
 
@@ -258,7 +258,7 @@ class HTTPXMock:
                 not not_called
             ), f"The following responses are mocked but not requested:\n{matchers_description}"
 
-    def _reset_callbacks(self) -> list[_RequestMatcher]:
+    def _reset_callbacks(self) -> List[_RequestMatcher]:
         callbacks_not_executed = [
             matcher for matcher, _ in self._callbacks if not matcher.nb_calls
         ]

--- a/pytest_httpx/_pretty_print.py
+++ b/pytest_httpx/_pretty_print.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List
 
 import httpx
 
@@ -11,7 +11,7 @@ class RequestDescription:
         self,
         real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
         request: httpx.Request,
-        matchers: list[_RequestMatcher],
+        matchers: List[_RequestMatcher],
     ):
         self.real_transport = real_transport
         self.request = request

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Optional, Union, Pattern, Any
+from typing import Optional, Union, Pattern, Any, Dict
 
 import httpx
 
@@ -30,7 +30,7 @@ class _RequestMatcher:
         url: Optional[Union[str, Pattern[str], httpx.URL]] = None,
         method: Optional[str] = None,
         proxy_url: Optional[Union[str, Pattern[str], httpx.URL]] = None,
-        match_headers: Optional[dict[str, Any]] = None,
+        match_headers: Optional[Dict[str, Any]] = None,
         match_content: Optional[bytes] = None,
         match_json: Optional[Any] = None,
     ):

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ setup(
         "Typing :: Typed",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Internet :: WWW/HTTP",
         "Framework :: Pytest",
@@ -39,7 +41,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.25.*", "pytest==7.*"],
+    install_requires=["httpx>=0.23.0", "pytest==7.*"],
     extras_require={
         "testing": [
             # Used to run async test functions
@@ -48,7 +50,7 @@ setup(
             "pytest-cov==4.*",
         ]
     },
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     project_urls={
         "GitHub": "https://github.com/Colin-b/pytest_httpx",
         "Changelog": "https://github.com/Colin-b/pytest_httpx/blob/master/CHANGELOG.md",


### PR DESCRIPTION
This PR loosens the versions constraints for Python so it supports 3.8. Some typing's are changed to become compatible with 3.8. Furthermore the test matrix is extended to test against the latest 3 httpx versions and Python 3.12. 

Closes #122 