### PR TITLE
Release 0.27.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,17 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-        pytest-major-version: ['6', '7']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest~=${{ matrix.pytest-major-version }}.0
         python -m pip install -e .[testing]
-    - name: Test with pytest v${{ matrix.pytest-major-version }}
+    - name: Test
       run: |
         pytest --cov=pytest_httpx --cov-fail-under=100 --cov-report=term-missing --runpytest=subprocess

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.11.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2023-09-18
+### Added
+- Added `proxy_url` parameter which allows matching on proxy URL.
+
 ## [0.25.0] - 2023-09-11
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.25.\*
@@ -283,7 +287,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...v0.23.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Custom HTTP transport are now handled (parent call to `handle_async_request` or `handle_request`).
+
+### Changed
+- Only HTTP transport are now mocked, this should not have any impact, however if it does, please feel free to open an issue describing your use case.
 
 ## [0.26.0] - 2023-09-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.27.0] - 2023-11-13
 ### Added
 - Explicit support for python `3.12`.
 
@@ -295,7 +297,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2023-09-11
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.25.\*
+
+### Removed
+- `pytest` `6` is no longer supported.
+
 ## [0.24.0] - 2023-09-04
 ### Added
 - Added `match_json` parameter which allows matching on JSON decoded body (matching against python representation instead of bytes).
@@ -276,7 +283,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.22.0...v0.23.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Explicit support for python `3.12`.
+
 ### Fixed
 - Custom HTTP transport are now handled (parent call to `handle_async_request` or `handle_request`).
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ from pytest_httpx import HTTPXMock
 
 
 def test_headers_matching(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(match_headers={'User-Agent': 'python-httpx/0.24.1'})
+    httpx_mock.add_response(match_headers={'User-Agent': 'python-httpx/0.25.0'})
 
     with httpx.Client() as client:
         response = client.get("https://test_url")

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-206 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-208 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-192 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-206 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -144,6 +144,26 @@ def test_head(httpx_mock: HTTPXMock):
     with httpx.Client() as client:
         response = client.head("https://test_url")
     
+```
+
+#### Matching on proxy URL
+
+`proxy_url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
+
+Matching is performed on the full proxy URL, query parameters included.
+
+Order of parameters in the query string does not matter, however order of values do matter if the same parameter is provided more than once.
+
+```python
+import httpx
+from pytest_httpx import HTTPXMock
+
+
+def test_proxy_url(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(proxy_url="http://test_proxy_url?a=1&b=2")
+
+    with httpx.Client(proxies={"https://": "http://test_proxy_url?a=2&b=1"}) as client:
+        response = client.get("https://test_url")
 ```
 
 #### Matching on HTTP headers
@@ -586,6 +606,8 @@ You can add criteria so that requests will be returned only in case of a more sp
 
 Matching is performed on the full URL, query parameters included.
 
+Order of parameters in the query string does not matter, however order of values do matter if the same parameter is provided more than once.
+
 #### Matching on HTTP method
 
 Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEAD) of the requests to retrieve.
@@ -593,6 +615,14 @@ Use `method` parameter to specify the HTTP method (POST, PUT, DELETE, PATCH, HEA
 `method` parameter must be a string. It will be upper-cased, so it can be provided lower cased.
 
 Matching is performed on equality.
+
+#### Matching on proxy URL
+
+`proxy_url` parameter can either be a string, a python [re.Pattern](https://docs.python.org/3/library/re.html) instance or a [httpx.URL](https://www.python-httpx.org/api/#url) instance.
+
+Matching is performed on the full proxy URL, query parameters included.
+
+Order of parameters in the query string does not matter, however order of values do matter if the same parameter is provided more than once.
 
 #### Matching on HTTP headers
 
@@ -605,6 +635,14 @@ Matching is performed on equality for each provided header.
 Use `match_content` parameter to specify the full HTTP body executing the callback.
 
 Matching is performed on equality.
+
+##### Matching on HTTP JSON body
+
+Use `match_json` parameter to specify the JSON decoded HTTP body executing the callback.
+
+Matching is performed on equality. You can however use `unittest.mock.ANY` to do partial matching.
+
+Note that `match_content` cannot be provided if `match_json` is also provided.
 
 ## Do not mock some requests
 

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -51,7 +51,7 @@ def httpx_mock(
         "_transport_for_url",
         lambda self, url: real_sync_transport(self, url)
         if url.host in non_mocked_hosts
-        else _PytestSyncTransport(mock),
+        else _PytestSyncTransport(real_sync_transport(self, url), mock),
     )
     # Mock asynchronous requests
     real_async_transport = httpx.AsyncClient._transport_for_url
@@ -60,7 +60,7 @@ def httpx_mock(
         "_transport_for_url",
         lambda self, url: real_async_transport(self, url)
         if url.host in non_mocked_hosts
-        else _PytestAsyncTransport(mock),
+        else _PytestAsyncTransport(real_async_transport(self, url), mock),
     )
     yield mock
     mock.reset(assert_all_responses_were_requested)

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -1,3 +1,4 @@
+import base64
 from typing import (
     Union,
     Dict,
@@ -6,8 +7,10 @@ from typing import (
     Iterable,
     AsyncIterator,
     Iterator,
+    Optional,
 )
 
+import httpcore
 import httpx
 
 # TODO Get rid of this internal import
@@ -36,3 +39,34 @@ class IteratorStream(AsyncIteratorByteStream, IteratorByteStream):
 
         AsyncIteratorByteStream.__init__(self, stream=Stream())
         IteratorByteStream.__init__(self, stream=Stream())
+
+
+def _to_httpx_url(url: httpcore.URL, headers: list[tuple[bytes, bytes]]) -> httpx.URL:
+    for name, value in headers:
+        if b"Proxy-Authorization" == name:
+            return httpx.URL(
+                scheme=url.scheme.decode(),
+                host=url.host.decode(),
+                port=url.port,
+                raw_path=url.target,
+                userinfo=base64.b64decode(value[6:]),
+            )
+
+    return httpx.URL(
+        scheme=url.scheme.decode(),
+        host=url.host.decode(),
+        port=url.port,
+        raw_path=url.target,
+    )
+
+
+def _proxy_url(
+    real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
+) -> Optional[httpx.URL]:
+    if isinstance(real_transport, httpx.HTTPTransport):
+        if isinstance(real_pool := real_transport._pool, httpcore.HTTPProxy):
+            return _to_httpx_url(real_pool._proxy_url, real_pool._proxy_headers)
+
+    if isinstance(real_transport, httpx.AsyncHTTPTransport):
+        if isinstance(real_pool := real_transport._pool, httpcore.AsyncHTTPProxy):
+            return _to_httpx_url(real_pool._proxy_url, real_pool._proxy_headers)

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -61,12 +61,9 @@ def _to_httpx_url(url: httpcore.URL, headers: list[tuple[bytes, bytes]]) -> http
 
 
 def _proxy_url(
-    real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
+    real_transport: Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport]
 ) -> Optional[httpx.URL]:
-    if isinstance(real_transport, httpx.HTTPTransport):
-        if isinstance(real_pool := real_transport._pool, httpcore.HTTPProxy):
-            return _to_httpx_url(real_pool._proxy_url, real_pool._proxy_headers)
-
-    if isinstance(real_transport, httpx.AsyncHTTPTransport):
-        if isinstance(real_pool := real_transport._pool, httpcore.AsyncHTTPProxy):
-            return _to_httpx_url(real_pool._proxy_url, real_pool._proxy_headers)
+    if isinstance(
+        real_pool := real_transport._pool, (httpcore.HTTPProxy, httpcore.AsyncHTTPProxy)
+    ):
+        return _to_httpx_url(real_pool._proxy_url, real_pool._proxy_headers)

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -12,7 +12,7 @@ from pytest_httpx._request_matcher import _RequestMatcher
 class HTTPXMock:
     def __init__(self) -> None:
         self._requests: list[
-            tuple[Union[httpx.BaseTransport, httpx.AsyncBaseTransport], httpx.Request]
+            tuple[Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport], httpx.Request]
         ] = []
         self._callbacks: list[
             tuple[
@@ -123,7 +123,7 @@ class HTTPXMock:
 
     def _handle_request(
         self,
-        real_transport: httpx.BaseTransport,
+        real_transport: httpx.HTTPTransport,
         request: httpx.Request,
     ) -> httpx.Response:
         self._requests.append((real_transport, request))
@@ -142,7 +142,7 @@ class HTTPXMock:
 
     async def _handle_async_request(
         self,
-        real_transport: httpx.AsyncBaseTransport,
+        real_transport: httpx.AsyncHTTPTransport,
         request: httpx.Request,
     ) -> httpx.Response:
         self._requests.append((real_transport, request))
@@ -178,7 +178,7 @@ class HTTPXMock:
 
     def _get_callback(
         self,
-        real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        real_transport: Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport],
         request: httpx.Request,
     ) -> Optional[
         Callable[
@@ -264,24 +264,6 @@ class HTTPXMock:
         ]
         self._callbacks.clear()
         return callbacks_not_executed
-
-
-class _PytestSyncTransport(httpx.BaseTransport):
-    def __init__(self, real_transport: httpx.BaseTransport, mock: HTTPXMock):
-        self._real_transport = real_transport
-        self._mock = mock
-
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
-        return self._mock._handle_request(self._real_transport, request)
-
-
-class _PytestAsyncTransport(httpx.AsyncBaseTransport):
-    def __init__(self, real_transport: httpx.AsyncBaseTransport, mock: HTTPXMock):
-        self._real_transport = real_transport
-        self._mock = mock
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        return await self._mock._handle_async_request(self._real_transport, request)
 
 
 def _unread(response: httpx.Response) -> httpx.Response:

--- a/pytest_httpx/_pretty_print.py
+++ b/pytest_httpx/_pretty_print.py
@@ -1,0 +1,67 @@
+from typing import Union
+
+import httpx
+
+from pytest_httpx._httpx_internals import _proxy_url
+from pytest_httpx._request_matcher import _RequestMatcher
+
+
+class RequestDescription:
+    def __init__(
+        self,
+        real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        request: httpx.Request,
+        matchers: list[_RequestMatcher],
+    ):
+        self.real_transport = real_transport
+        self.request = request
+
+        headers_encoding = request.headers.encoding
+        self.expected_headers = set(
+            [
+                # httpx uses lower cased header names as internal key
+                header.lower().encode(headers_encoding)
+                for matcher in matchers
+                if matcher.headers
+                for header in matcher.headers
+            ]
+        )
+        self.expect_body = any(
+            [
+                matcher.content is not None or matcher.json is not None
+                for matcher in matchers
+            ]
+        )
+        self.expect_proxy = any([matcher.proxy_url is not None for matcher in matchers])
+
+    def __str__(self) -> str:
+        request_description = f"{self.request.method} request on {self.request.url}"
+        if extra_description := self.extra_request_description():
+            request_description += f" with {extra_description}"
+        return request_description
+
+    def extra_request_description(self) -> str:
+        extra_description = []
+
+        if self.expected_headers:
+            headers_encoding = self.request.headers.encoding
+            present_headers = {}
+            # Can be cleaned based on the outcome of https://github.com/encode/httpx/discussions/2841
+            for name, lower_name, value in self.request.headers._list:
+                if lower_name in self.expected_headers:
+                    name = name.decode(headers_encoding)
+                    if name in present_headers:
+                        present_headers[name] += f", {value.decode(headers_encoding)}"
+                    else:
+                        present_headers[name] = value.decode(headers_encoding)
+
+            extra_description.append(f"{present_headers} headers")
+
+        if self.expect_body:
+            extra_description.append(f"{self.request.read()} body")
+
+        if self.expect_proxy:
+            proxy_url = _proxy_url(self.real_transport)
+            extra_description.append(f"{proxy_url if proxy_url else 'no'} proxy URL")
+
+        return " and ".join(extra_description)

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -1,0 +1,139 @@
+import json
+import re
+from typing import Optional, Union, Pattern, Any
+
+import httpx
+
+from pytest_httpx._httpx_internals import _proxy_url
+
+
+def _url_match(
+    url_to_match: Union[Pattern[str], httpx.URL], received: httpx.URL
+) -> bool:
+    if isinstance(url_to_match, re.Pattern):
+        return url_to_match.match(str(received)) is not None
+
+    # Compare query parameters apart as order of parameters should not matter
+    received_params = dict(received.params)
+    params = dict(url_to_match.params)
+
+    # Remove the query parameters from the original URL to compare everything besides query parameters
+    received_url = received.copy_with(query=None)
+    url = url_to_match.copy_with(query=None)
+
+    return (received_params == params) and (url == received_url)
+
+
+class _RequestMatcher:
+    def __init__(
+        self,
+        url: Optional[Union[str, Pattern[str], httpx.URL]] = None,
+        method: Optional[str] = None,
+        proxy_url: Optional[Union[str, Pattern[str], httpx.URL]] = None,
+        match_headers: Optional[dict[str, Any]] = None,
+        match_content: Optional[bytes] = None,
+        match_json: Optional[Any] = None,
+    ):
+        self.nb_calls = 0
+        self.url = httpx.URL(url) if url and isinstance(url, str) else url
+        self.method = method.upper() if method else method
+        self.headers = match_headers
+        if match_content is not None and match_json is not None:
+            raise ValueError(
+                "Only one way of matching against the body can be provided. If you want to match against the JSON decoded representation, use match_json. Otherwise, use match_content."
+            )
+        self.content = match_content
+        self.json = match_json
+        self.proxy_url = (
+            httpx.URL(proxy_url)
+            if proxy_url and isinstance(proxy_url, str)
+            else proxy_url
+        )
+
+    def match(
+        self,
+        real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        request: httpx.Request,
+    ) -> bool:
+        return (
+            self._url_match(request)
+            and self._method_match(request)
+            and self._headers_match(request)
+            and self._content_match(request)
+            and self._proxy_match(real_transport)
+        )
+
+    def _url_match(self, request: httpx.Request) -> bool:
+        if not self.url:
+            return True
+
+        return _url_match(self.url, request.url)
+
+    def _method_match(self, request: httpx.Request) -> bool:
+        if not self.method:
+            return True
+
+        return request.method == self.method
+
+    def _headers_match(self, request: httpx.Request) -> bool:
+        if not self.headers:
+            return True
+
+        encoding = request.headers.encoding
+        request_headers = {}
+        # Can be cleaned based on the outcome of https://github.com/encode/httpx/discussions/2841
+        for raw_name, raw_value in request.headers.raw:
+            if raw_name in request_headers:
+                request_headers[raw_name] += b", " + raw_value
+            else:
+                request_headers[raw_name] = raw_value
+
+        return all(
+            request_headers.get(header_name.encode(encoding))
+            == header_value.encode(encoding)
+            for header_name, header_value in self.headers.items()
+        )
+
+    def _content_match(self, request: httpx.Request) -> bool:
+        if self.content is None and self.json is None:
+            return True
+        if self.content is not None:
+            return request.read() == self.content
+        try:
+            # httpx._content.encode_json hard codes utf-8 encoding.
+            return json.loads(request.read().decode("utf-8")) == self.json
+        except json.decoder.JSONDecodeError:
+            return False
+
+    def _proxy_match(
+        self, real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
+    ) -> bool:
+        if not self.proxy_url:
+            return True
+
+        if real_proxy_url := _proxy_url(real_transport):
+            return _url_match(self.proxy_url, real_proxy_url)
+
+        return False
+
+    def __str__(self) -> str:
+        matcher_description = f"Match {self.method or 'all'} requests"
+        if self.url:
+            matcher_description += f" on {self.url}"
+        if extra_description := self._extra_description():
+            matcher_description += f" with {extra_description}"
+        return matcher_description
+
+    def _extra_description(self) -> str:
+        extra_description = []
+
+        if self.headers:
+            extra_description.append(f"{self.headers} headers")
+        if self.content is not None:
+            extra_description.append(f"{self.content} body")
+        if self.json is not None:
+            extra_description.append(f"{self.json} json body")
+        if self.proxy_url:
+            extra_description.append(f"{self.proxy_url} proxy URL")
+
+        return " and ".join(extra_description)

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -52,7 +52,7 @@ class _RequestMatcher:
 
     def match(
         self,
-        real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        real_transport: Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport],
         request: httpx.Request,
     ) -> bool:
         return (
@@ -106,7 +106,7 @@ class _RequestMatcher:
             return False
 
     def _proxy_match(
-        self, real_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
+        self, real_transport: Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport]
     ) -> bool:
         if not self.proxy_url:
             return True

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"pytest_httpx": ["py.typed"]},
     entry_points={"pytest11": ["pytest_httpx = pytest_httpx"]},
-    install_requires=["httpx==0.24.*", "pytest>=6.0,<8.0"],
+    install_requires=["httpx==0.25.*", "pytest==7.*"],
     extras_require={
         "testing": [
             # Used to run async test functions

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Internet :: WWW/HTTP",
         "Framework :: Pytest",

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -1230,6 +1230,119 @@ async def test_content_matching(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
+async def test_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://user:pwd@my_other_proxy/")
+
+    async with httpx.AsyncClient(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        response = await client.get("https://test_url")
+        assert response.read() == b""
+
+
+@pytest.mark.asyncio
+async def test_proxy_not_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://my_test_proxy")
+
+    async with httpx.AsyncClient(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        with pytest.raises(httpx.TimeoutException) as exception_info:
+            await client.get("http://test_url")
+        assert (
+            str(exception_info.value)
+            == """No response can be found for GET request on http://test_url with http://my_test_proxy/ proxy URL amongst:
+Match all requests with http://my_test_proxy proxy URL"""
+        )
+
+    # Clean up responses to avoid assertion failure
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+
+@pytest.mark.asyncio
+async def test_proxy_not_existing(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://my_test_proxy")
+
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.TimeoutException) as exception_info:
+            await client.get("http://test_url")
+        assert (
+            str(exception_info.value)
+            == """No response can be found for GET request on http://test_url with no proxy URL amongst:
+Match all requests with http://my_test_proxy proxy URL"""
+        )
+
+    # Clean up responses to avoid assertion failure
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+
+@pytest.mark.asyncio
+async def test_requests_retrieval_content_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.post("https://test_url", content=b"This is the body")
+        await client.post("https://test_url2", content=b"This is the body")
+        await client.post("https://test_url2", content=b"This is the body2")
+
+    assert len(httpx_mock.get_requests(match_content=b"This is the body")) == 2
+
+
+@pytest.mark.asyncio
+async def test_requests_retrieval_json_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient() as client:
+        await client.post("https://test_url", json=["my_str"])
+        await client.post("https://test_url2", json=["my_str"])
+        await client.post("https://test_url2", json=["my_str2"])
+
+    assert len(httpx_mock.get_requests(match_json=["my_str"])) == 2
+
+
+@pytest.mark.asyncio
+async def test_requests_retrieval_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        await client.get("https://test_url")
+        await client.get("https://test_url2")
+        await client.get("http://test_url2")
+
+    assert (
+        len(httpx_mock.get_requests(proxy_url="http://user:pwd@my_other_proxy/")) == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_retrieval_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        await client.get("https://test_url")
+        await client.get("https://test_url2")
+        await client.get("http://test_url2")
+
+    assert httpx_mock.get_request(proxy_url="http://my_test_proxy/")
+
+
+@pytest.mark.asyncio
 async def test_content_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_content=b"This is the body")
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -2015,3 +2015,26 @@ async def test_streams_are_not_cascading_resulting_in_maximum_recursion(
         tasks = [client.get("https://example.com/") for _ in range(950)]
         await asyncio.gather(*tasks)
     # No need to assert anything, this test case ensure that no error was raised by the gather
+
+
+@pytest.mark.asyncio
+async def test_custom_transport(httpx_mock: HTTPXMock) -> None:
+    class CustomTransport(httpx.AsyncHTTPTransport):
+        def __init__(self, prefix: str, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.prefix = prefix
+
+        async def handle_async_request(
+            self,
+            request: httpx.Request,
+        ) -> httpx.Response:
+            httpx_response = await super().handle_async_request(request)
+            httpx_response.headers["x-prefix"] = self.prefix
+            return httpx_response
+
+    httpx_mock.add_response()
+
+    async with httpx.AsyncClient(transport=CustomTransport(prefix="test")) as client:
+        response = await client.post("https://test_url", content=b"This is the body")
+        assert response.read() == b""
+        assert response.headers["x-prefix"] == "test"

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -977,6 +977,112 @@ def test_content_matching(httpx_mock: HTTPXMock) -> None:
         assert response.read() == b""
 
 
+def test_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://user:pwd@my_other_proxy/")
+
+    with httpx.Client(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        response = client.get("https://test_url")
+        assert response.read() == b""
+
+
+def test_proxy_not_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://my_test_proxy")
+
+    with httpx.Client(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        with pytest.raises(httpx.TimeoutException) as exception_info:
+            client.get("http://test_url")
+        assert (
+            str(exception_info.value)
+            == """No response can be found for GET request on http://test_url with http://my_test_proxy/ proxy URL amongst:
+Match all requests with http://my_test_proxy proxy URL"""
+        )
+
+    # Clean up responses to avoid assertion failure
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+
+def test_proxy_not_existing(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(proxy_url="http://my_test_proxy")
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.TimeoutException) as exception_info:
+            client.get("http://test_url")
+        assert (
+            str(exception_info.value)
+            == """No response can be found for GET request on http://test_url with no proxy URL amongst:
+Match all requests with http://my_test_proxy proxy URL"""
+        )
+
+    # Clean up responses to avoid assertion failure
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+
+def test_requests_retrieval_content_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        client.post("https://test_url", content=b"This is the body")
+        client.post("https://test_url2", content=b"This is the body")
+        client.post("https://test_url2", content=b"This is the body2")
+
+    assert len(httpx_mock.get_requests(match_content=b"This is the body")) == 2
+
+
+def test_requests_retrieval_json_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client() as client:
+        client.post("https://test_url", json=["my_str"])
+        client.post("https://test_url2", json=["my_str"])
+        client.post("https://test_url2", json=["my_str2"])
+
+    assert len(httpx_mock.get_requests(match_json=["my_str"])) == 2
+
+
+def test_requests_retrieval_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        client.get("https://test_url")
+        client.get("https://test_url2")
+        client.get("http://test_url2")
+
+    assert (
+        len(httpx_mock.get_requests(proxy_url="http://user:pwd@my_other_proxy/")) == 2
+    )
+
+
+def test_request_retrieval_proxy_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response()
+
+    with httpx.Client(
+        proxies={
+            "http://": "http://my_test_proxy",
+            "https://": "http://user:pwd@my_other_proxy",
+        }
+    ) as client:
+        client.get("https://test_url")
+        client.get("https://test_url2")
+        client.get("http://test_url2")
+
+    assert httpx_mock.get_request(proxy_url="http://my_test_proxy/")
+
+
 def test_content_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(match_content=b"This is the body")
 


### PR DESCRIPTION
### Added
- Explicit support for python `3.12`.

### Fixed
- Custom HTTP transport are now handled (parent call to `handle_async_request` or `handle_request`).

### Changed
- Only HTTP transport are now mocked, this should not have any impact, however if it does, please feel free to open an issue describing your use case.
