### PR TITLE
really drop python<=3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ maintainers = [
 ]
 keywords = [
     "httpx",
-    "mock",
     "pytest",
     "testing",
 ]

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -22,7 +22,7 @@ def assert_all_responses_were_requested() -> bool:
 
 
 @pytest.fixture
-def non_mocked_hosts() -> List[str]:
+def non_mocked_hosts() -> list[str]:
     return []
 
 
@@ -30,7 +30,7 @@ def non_mocked_hosts() -> List[str]:
 def httpx_mock(
     monkeypatch: MonkeyPatch,
     assert_all_responses_were_requested: bool,
-    non_mocked_hosts: List[str],
+    non_mocked_hosts: list[str],
 ) -> Generator[HTTPXMock, None, None]:
     # Ensure redirections to www hosts are handled transparently.
     missing_www = [

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -2,13 +2,10 @@ import base64
 from typing import (
     Union,
     Dict,
-    Sequence,
     Tuple,
-    Iterable,
-    AsyncIterator,
-    Iterator,
     Optional,
 )
+from collections.abc import Sequence, Iterable, AsyncIterator, Iterator
 
 import httpcore
 import httpx
@@ -19,10 +16,10 @@ from httpx._content import IteratorByteStream, AsyncIteratorByteStream
 # Those types are internally defined within httpx._types
 HeaderTypes = Union[
     httpx.Headers,
-    Dict[str, str],
-    Dict[bytes, bytes],
-    Sequence[Tuple[str, str]],
-    Sequence[Tuple[bytes, bytes]],
+    dict[str, str],
+    dict[bytes, bytes],
+    Sequence[tuple[str, str]],
+    Sequence[tuple[bytes, bytes]],
 ]
 
 

--- a/pytest_httpx/_httpx_internals.py
+++ b/pytest_httpx/_httpx_internals.py
@@ -30,8 +30,7 @@ class IteratorStream(AsyncIteratorByteStream, IteratorByteStream):
     def __init__(self, stream: Iterable[bytes]):
         class Stream:
             def __iter__(self) -> Iterator[bytes]:
-                for chunk in stream:
-                    yield chunk
+                yield from stream
 
             async def __aiter__(self) -> AsyncIterator[bytes]:
                 for chunk in stream:

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,6 +1,7 @@
 import copy
 import inspect
-from typing import Union, Optional, Callable, Any, Awaitable
+from typing import Union, Optional, Callable, Any
+from collections.abc import Awaitable
 
 import httpx
 

--- a/pytest_httpx/_pretty_print.py
+++ b/pytest_httpx/_pretty_print.py
@@ -17,15 +17,13 @@ class RequestDescription:
         self.request = request
 
         headers_encoding = request.headers.encoding
-        self.expected_headers = set(
-            [
+        self.expected_headers = {
                 # httpx uses lower cased header names as internal key
                 header.lower().encode(headers_encoding)
                 for matcher in matchers
                 if matcher.headers
                 for header in matcher.headers
-            ]
-        )
+        }
         self.expect_body = any(
             [
                 matcher.content is not None or matcher.json is not None

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -1,6 +1,7 @@
 import json
 import re
-from typing import Optional, Union, Pattern, Any
+from typing import Optional, Union, Any
+from re import Pattern
 
 import httpx
 


### PR DESCRIPTION
Filter all the code over `pyupgrade --py38`.