### PR TITLE
Setup httpx_mock via marker instead of fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The `httpx_mock` fixture is now configured using a marker.
+  ```python
+  # Apply marker to whole module
+  pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+  
+  # Or to specific tests
+  @pytest.mark.httpx_mock(non_mocked_hosts=[...])
+  def test_foo(httpx_mock):
+      ...
+  ```
+### Deprecated
+- `assert_all_responses_were_requested` fixture
+- `non_mocked_hosts` fixture
 
 ## [0.30.0] - 2024-02-21
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,14 +56,18 @@ async def test_something_async(httpx_mock):
 
 If all registered responses are not sent back during test execution, the test case will fail at teardown.
 
-This behavior can be disabled thanks to the `assert_all_responses_were_requested` fixture:
+This behavior can be disabled thanks to the `httpx_mock` marker:
 
 ```python
 import pytest
 
-@pytest.fixture
-def assert_all_responses_were_requested() -> bool:
-    return False
+# For whole module
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+# For specific test
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=True)
+def test_something(httpx_mock):
+    ...
 ```
 
 Default response is a HTTP/1.1 200 (OK) without any body.
@@ -456,14 +460,18 @@ Callback should expect one parameter, the received [`httpx.Request`](https://www
 
 If all callbacks are not executed during test execution, the test case will fail at teardown.
 
-This behavior can be disabled thanks to the `assert_all_responses_were_requested` fixture:
+This behavior can be disabled thanks to the `httpx_mock` marker:
 
 ```python
 import pytest
 
-@pytest.fixture
-def assert_all_responses_were_requested() -> bool:
-    return False
+# For whole module
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+# For specific test
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=True)
+def test_something(httpx_mock):
+    ...
 ```
 
 Note that callbacks are considered as responses, and thus are [selected the same way](#how-response-is-selected).
@@ -650,14 +658,18 @@ By default, `pytest-httpx` will mock every request.
 
 But, for instance, in case you want to write integration tests with other servers, you might want to let some requests go through.
 
-To do so, you can use the `non_mocked_hosts` fixture:
+To do so, you can use the `httpx_mock` marker:
 
 ```python
 import pytest
 
-@pytest.fixture
-def non_mocked_hosts() -> list:
-    return ["my_local_test_host", "my_other_test_host"]
+# For whole module
+pytestmark = pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host", "my_other_test_host"])
+
+# For specific test
+@pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"])
+def test_something(httpx_mock):
+    ...
 ```
 
 Every other requested hosts will be mocked as in the following example
@@ -666,11 +678,7 @@ Every other requested hosts will be mocked as in the following example
 import pytest
 import httpx
 
-@pytest.fixture
-def non_mocked_hosts() -> list:
-    return ["my_local_test_host"]
-
-
+@pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"])
 def test_partial_mock(httpx_mock):
     httpx_mock.add_response()
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,8 +1,11 @@
 import copy
 import inspect
+from functools import cached_property
+from operator import methodcaller
 from typing import Union, Optional, Callable, Any, Awaitable
 
 import httpx
+from pytest import Mark
 
 from pytest_httpx import _httpx_internals
 from pytest_httpx._pretty_print import RequestDescription
@@ -264,6 +267,51 @@ class HTTPXMock:
         ]
         self._callbacks.clear()
         return callbacks_not_executed
+
+
+class HTTPXMockOptions:
+    def __init__(
+        self,
+        *,
+        assert_all_responses_were_requested: bool = True,
+        non_mocked_hosts: Optional[list[str]] = None,
+    ) -> None:
+        if non_mocked_hosts is None:
+            non_mocked_hosts = []
+
+        self.assert_all_responses_were_requested = assert_all_responses_were_requested
+
+        # The original non_mocked_hosts list is shown in the __repr__, see the
+        # non_mocked_hosts property for more.
+        self._non_mocked_hosts = non_mocked_hosts
+
+    @classmethod
+    def from_marker(cls, marker: Mark) -> "HTTPXMockOptions":
+        """Initialise from a marker so that the marker kwargs raise an error if
+        incorrect.
+        """
+        __tracebackhide__ = methodcaller("errisinstance", TypeError)
+        return cls(**marker.kwargs)
+
+    @cached_property
+    def non_mocked_hosts(self) -> list[str]:
+        # Ensure redirections to www hosts are handled transparently.
+        missing_www = [
+            f"www.{host}"
+            for host in self._non_mocked_hosts
+            if not host.startswith("www.")
+        ]
+        return [*self._non_mocked_hosts, *missing_www]
+
+    def __repr__(self) -> str:
+        kwargs = []
+        if not self.assert_all_responses_were_requested:
+            kwargs.append(
+                f"assert_all_responses_were_requested={self.assert_all_responses_were_requested!r}"
+            )
+        if self._non_mocked_hosts:
+            kwargs.append(f"non_mocked_hosts={self._non_mocked_hosts!r}")
+        return f"pytest.mark.httpx_mock(" + ", ".join(kwargs) + ")"
 
 
 def _unread(response: httpx.Response) -> httpx.Response:


### PR DESCRIPTION
Resolves #137

We want to be able to configure how the `httpx_mock` fixture behaves at different scopes. A pytest marker can be used at module, class, or test scope and so is what is used here.

Providing a non-default value from the fixtures will emit a DeprecationWarning for each test with the exact marker it can be replaced with:

```
=================================== warnings summary ===================================
tests/test_tmp.py::test_a
tests/test_tmp.py::test_b
  /.../pytest_httpx/__init__.py:56: DeprecationWarning: The assert_all_responses_were_requested and non_mocked_hosts fixtures are deprecated.
  Use the following marker instead:

  pytest.mark.httpx_mock(assert_all_responses_were_requested=False)

    warnings.warn(

tests/test_tmp.py::test_c
  /.../pytest_httpx/__init__.py:56: DeprecationWarning: The assert_all_responses_were_requested and non_mocked_hosts fixtures are deprecated.
  Use the following marker instead:

  pytest.mark.httpx_mock(non_mocked_hosts=['example.com'])

    warnings.warn(

```