### PR TITLE
Bug fix to allow multiple builds of package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,5 @@ testing = [
 [project.entry-points.pytest11]
 pytest_httpx = "pytest_httpx"
 
-[tool.setuptools.packages.find]
-exclude = ["tests*"]
-
 [tool.setuptools.dynamic]
 version = {attr = "pytest_httpx.version.__version__"}


### PR DESCRIPTION
The `[tool.setuptools.packages.find]` section in `pyproject.toml` was removed because it didn't affect the generated wheel, as the wheel still excluded the `tests` directory with this section removed.

Including `[tool.setuptools.packages.find]` caused issues with multiple builds of the package. This led to the creation of infinite nested `build/lib/build/lib` directories. By removing this section, the default behaviour now ignores 'build*' directories, preventing these problems.

For more details, refer to the related discussion on the setuptools: https://github.com/pypa/setuptools/issues/4076