### PR TITLE
Release 0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.2] - 2024-09-23
+### Fixed
+- `httpx_mock` marker can now be defined at different levels for a single test.
+
 ## [0.31.1] - 2024-09-22
 ### Fixed
 - It is now possible to match on content provided as async iterable by the client.
@@ -341,7 +345,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.1...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.2...HEAD
+[0.31.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.29.0...v0.30.0

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ This behavior can be disabled thanks to the `httpx_mock` marker:
 ```python
 import pytest
 
+# For the whole test suite, to add to the root conftest.py file
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item.add_marker(pytest.mark.httpx_mock(assert_all_responses_were_requested=False))
+
 # For whole module
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
@@ -465,6 +470,11 @@ This behavior can be disabled thanks to the `httpx_mock` marker:
 ```python
 import pytest
 
+# For the whole test suite, to add to the root conftest.py file
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item.add_marker(pytest.mark.httpx_mock(assert_all_responses_were_requested=False))
+
 # For whole module
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
@@ -578,6 +588,11 @@ Note that default behavior is to assert that all requests were expected. You can
 ```python
 import pytest
 
+# For the whole test suite, to add to the root conftest.py file
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item.add_marker(pytest.mark.httpx_mock(assert_all_requests_were_expected=False))
+
 # For whole module
 pytestmark = pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
 
@@ -677,6 +692,11 @@ To do so, you can use the `httpx_mock` marker:
 
 ```python
 import pytest
+
+# For the whole test suite, to add to the root conftest.py file
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item.add_marker(pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"]))
 
 # For whole module
 pytestmark = pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host", "my_other_test_host"])

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-215 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-216 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from operator import methodcaller
 
 import httpx
 import pytest
@@ -20,8 +21,11 @@ def httpx_mock(
     monkeypatch: MonkeyPatch,
     request: FixtureRequest,
 ) -> Generator[HTTPXMock, None, None]:
-    marker = request.node.get_closest_marker("httpx_mock")
-    options = HTTPXMockOptions.from_marker(marker) if marker else HTTPXMockOptions()
+    options = {}
+    for marker in request.node.iter_markers("httpx_mock"):
+        options = marker.kwargs | options
+    __tracebackhide__ = methodcaller("errisinstance", TypeError)
+    options = HTTPXMockOptions(**options)
 
     mock = HTTPXMock()
 

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -1,11 +1,9 @@
 import copy
 import inspect
-from operator import methodcaller
-from typing import Union, Optional, Callable, Any, NoReturn, AsyncIterable
-from collections.abc import Awaitable, Iterable
+from typing import Union, Optional, Callable, Any, NoReturn
+from collections.abc import Awaitable
 
 import httpx
-from pytest import Mark
 
 from pytest_httpx import _httpx_internals
 from pytest_httpx._pretty_print import RequestDescription
@@ -31,12 +29,6 @@ class HTTPXMockOptions:
             f"www.{host}" for host in non_mocked_hosts if not host.startswith("www.")
         ]
         self.non_mocked_hosts = [*non_mocked_hosts, *missing_www]
-
-    @classmethod
-    def from_marker(cls, marker: Mark) -> "HTTPXMockOptions":
-        """Initialise from a marker so that the marker kwargs raise an error if incorrect."""
-        __tracebackhide__ = methodcaller("errisinstance", TypeError)
-        return cls(**marker.kwargs)
 
 
 class HTTPXMock:

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.31.1"
+__version__ = "0.31.2"


### PR DESCRIPTION
### Fixed
- `httpx_mock` marker can now be defined at different levels for a single test.

@fixes #154
@fixed #155