### PR TITLE
Release 0.33.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Create packages
       run: |
         python -m pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit support for python `3.13`.
 - The following option is now available:
   - `should_mock` (callable returning a boolean), defaulting to always returning `True`.
+- Matching on the full multipart body can now be performed using `match_files` and `match_data` parameters.
 
 ### Removed
 - `non_mocked_hosts` option is not available anymore. Use `should_mock` instead as in the following sample:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.33.0] - 2024-10-28
 ### Added
 - Explicit support for python `3.13`.
-- The following option is now available:
-  - `should_mock` (callable returning a boolean), defaulting to always returning `True`.
-- Matching on the full multipart body can now be performed using `match_files` and `match_data` parameters.
-- Matching on extensions (including timeout) can now be performed using `match_extensions` parameter.
+- `should_mock` option (callable returning a boolean) is now available, defaulting to always returning `True`. Refer to documentation for more details.
+- Matching on the full multipart body can now be performed using `match_files` and `match_data` parameters. Refer to documentation for more details.
+- Matching on extensions (including timeout) can now be performed using `match_extensions` parameter. Refer to documentation for more details.
 
 ### Removed
 - `non_mocked_hosts` option is not available anymore. Use `should_mock` instead as in the following sample:
@@ -395,7 +396,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release, should be considered as unstable for now as design might change.
 
-[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pytest_httpx/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Colin-b/pytest_httpx/compare/v0.31.0...v0.31.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Explicit support for python `3.13`.
+- The following option is now available:
+  - `should_mock` (callable returning a boolean), defaulting to always returning `True`.
+
+### Removed
+- `non_mocked_hosts` option is not available anymore. Use `should_mock` instead as in the following sample:
+  ```python
+  import pytest
+  
+  @pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"])
+  def test_previous_behavior(httpx_mock):
+      ...
+  
+  @pytest.mark.httpx_mock(should_mock=lambda request: request.url.host not in ["my_local_test_host"])
+  def test_new_behavior(httpx_mock):
+      ...
+  ```
+  Please note that your hosts might need to be prefixed with `www.` depending on your usage.
 
 ## [0.32.0] - 2024-09-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following option is now available:
   - `should_mock` (callable returning a boolean), defaulting to always returning `True`.
 - Matching on the full multipart body can now be performed using `match_files` and `match_data` parameters.
+- Matching on extensions (including timeout) can now be performed using `match_extensions` parameter.
 
 ### Removed
 - `non_mocked_hosts` option is not available anymore. Use `should_mock` instead as in the following sample:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-229 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-248 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -237,7 +237,26 @@ def test_partial_json_matching(httpx_mock: HTTPXMock):
         response = client.post("https://test_url", json={"a": "json", "b": 2})
 ```
         
-Note that `match_content` cannot be provided if `match_json` is also provided.
+Note that `match_content` or `match_files` cannot be provided if `match_json` is also provided.
+
+##### Matching on HTTP multipart body
+
+Use `match_files` and `match_data` parameters to specify the full multipart body to reply to.
+
+Matching is performed on equality.
+
+```python
+import httpx
+from pytest_httpx import HTTPXMock
+
+def test_multipart_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(match_files={"name": ("file_name", b"File content")}, match_data={"field": "value"})
+
+    with httpx.Client() as client:
+        response = client.post("https://test_url", files={"name": ("file_name", b"File content")}, data={"field": "value"})
+```
+        
+Note that `match_content` or `match_json` cannot be provided if `match_files` is also provided.
 
 ### Add JSON response
 

--- a/README.md
+++ b/README.md
@@ -728,14 +728,15 @@ By default, `pytest-httpx` will mock every request.
 
 But, for instance, in case you want to write integration tests with other servers, you might want to let some requests go through.
 
-To do so, you can use the `httpx_mock` marker `non_mocked_hosts` option and provide a list of non mocked hosts.
-Every other requested hosts will be mocked as in the following example
+To do so, you can use the `httpx_mock` marker `should_mock` option and provide a callable expecting the [`httpx.Request`](https://www.python-httpx.org/api/#request) as parameter and returning a boolean.
+
+Returning `True` will ensure that the request is handled by `pytest-httpx` (mocked), `False` will let the request pass through (not mocked).
 
 ```python
 import pytest
 import httpx
 
-@pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"])
+@pytest.mark.httpx_mock(should_mock=lambda request: request.url.host != "www.my_local_test_host")
 def test_partial_mock(httpx_mock):
     httpx_mock.add_response()
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Build status" src="https://github.com/Colin-b/pytest_httpx/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-248 passed-blue"></a>
+<a href="https://github.com/Colin-b/pytest_httpx/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-260 passed-blue"></a>
 <a href="https://pypi.org/project/pytest-httpx/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pytest_httpx"></a>
 </p>
 
@@ -257,6 +257,42 @@ def test_multipart_matching(httpx_mock: HTTPXMock):
 ```
         
 Note that `match_content` or `match_json` cannot be provided if `match_files` is also provided.
+
+#### Matching on extensions
+
+Use `match_extensions` parameter to specify the extensions (as a dict) to reply to.
+
+Matching is performed on equality for each provided extension.
+
+```python
+import httpx
+from pytest_httpx import HTTPXMock
+
+
+def test_extensions_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(match_extensions={'test': 'value'})
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url", extensions={"test": "value"})
+```
+
+##### Matching on HTTP timeout(s)
+
+Use `match_extensions` parameter to specify the timeouts (as a dict) to reply to.
+
+Matching is performed on the full timeout dict equality.
+
+```python
+import httpx
+from pytest_httpx import HTTPXMock
+
+
+def test_timeout_matching(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(match_extensions={'timeout': {'connect': 10, 'read': 10, 'write': 10, 'pool': 10}})
+
+    with httpx.Client() as client:
+        response = client.get("https://test_url", timeout=10)
+```
 
 ### Add JSON response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed",

--- a/pytest_httpx/__init__.py
+++ b/pytest_httpx/__init__.py
@@ -36,9 +36,9 @@ def httpx_mock(
     def mocked_handle_request(
         transport: httpx.HTTPTransport, request: httpx.Request
     ) -> httpx.Response:
-        if request.url.host in options.non_mocked_hosts:
-            return real_handle_request(transport, request)
-        return mock._handle_request(transport, request)
+        if options.should_mock(request):
+            return mock._handle_request(transport, request)
+        return real_handle_request(transport, request)
 
     monkeypatch.setattr(
         httpx.HTTPTransport,
@@ -52,9 +52,9 @@ def httpx_mock(
     async def mocked_handle_async_request(
         transport: httpx.AsyncHTTPTransport, request: httpx.Request
     ) -> httpx.Response:
-        if request.url.host in options.non_mocked_hosts:
-            return await real_handle_async_request(transport, request)
-        return await mock._handle_async_request(transport, request)
+        if options.should_mock(request):
+            return await mock._handle_async_request(transport, request)
+        return await real_handle_async_request(transport, request)
 
     monkeypatch.setattr(
         httpx.AsyncHTTPTransport,
@@ -72,5 +72,5 @@ def httpx_mock(
 def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         "markers",
-        "httpx_mock(*, assert_all_responses_were_requested=True, assert_all_requests_were_expected=True, can_send_already_matched_responses=False, non_mocked_hosts=[]): Configure httpx_mock fixture.",
+        "httpx_mock(*, assert_all_responses_were_requested=True, assert_all_requests_were_expected=True, can_send_already_matched_responses=False, should_mock=lambda request: True): Configure httpx_mock fixture.",
     )

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -66,8 +66,9 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
-        :param match_data: Multipart data (excluding files). Must be a dictionary.
-        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
+        :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
         """
 
         json = copy.deepcopy(json) if json is not None else None
@@ -107,8 +108,9 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
-        :param match_data: Multipart data (excluding files). Must be a dictionary.
-        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
+        :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
         """
         self._callbacks.append((_RequestMatcher(self._options, **matchers), callback))
 
@@ -125,8 +127,9 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
-        :param match_data: Multipart data (excluding files). Must be a dictionary.
-        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
+        :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
         """
 
         def exception_callback(request: httpx.Request) -> None:
@@ -261,8 +264,9 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the requests to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the requests to retrieve. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the requests to retrieve. Must be JSON encodable.
-        :param match_data: Multipart data (excluding files). Must be a dictionary.
-        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_data: Multipart data (excluding files) identifying the requests to retrieve. Must be a dictionary.
+        :param match_files: Multipart files identifying the requests to retrieve. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the requests to retrieve. Must be a dictionary.
         """
         matcher = _RequestMatcher(self._options, **matchers)
         return [
@@ -283,8 +287,9 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request to retrieve. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request to retrieve. Must be JSON encodable.
-        :param match_data: Multipart data (excluding files). Must be a dictionary.
-        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_data: Multipart data (excluding files) identifying the request to retrieve. Must be a dictionary.
+        :param match_files: Multipart files identifying the request to retrieve. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the request to retrieve. Must be a dictionary.
         :raises AssertionError: in case more than one request match.
         """
         requests = self.get_requests(**matchers)

--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -66,6 +66,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
+        :param match_data: Multipart data (excluding files). Must be a dictionary.
+        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         """
 
         json = copy.deepcopy(json) if json is not None else None
@@ -105,6 +107,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
+        :param match_data: Multipart data (excluding files). Must be a dictionary.
+        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         """
         self._callbacks.append((_RequestMatcher(self._options, **matchers), callback))
 
@@ -121,6 +125,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request(s) to match. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request(s) to match. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
+        :param match_data: Multipart data (excluding files). Must be a dictionary.
+        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         """
 
         def exception_callback(request: httpx.Request) -> None:
@@ -255,6 +261,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the requests to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the requests to retrieve. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the requests to retrieve. Must be JSON encodable.
+        :param match_data: Multipart data (excluding files). Must be a dictionary.
+        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         """
         matcher = _RequestMatcher(self._options, **matchers)
         return [
@@ -275,6 +283,8 @@ class HTTPXMock:
         :param match_headers: HTTP headers identifying the request to retrieve. Must be a dictionary.
         :param match_content: Full HTTP body identifying the request to retrieve. Must be bytes.
         :param match_json: JSON decoded HTTP body identifying the request to retrieve. Must be JSON encodable.
+        :param match_data: Multipart data (excluding files). Must be a dictionary.
+        :param match_files: Multipart files. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         :raises AssertionError: in case more than one request match.
         """
         requests = self.get_requests(**matchers)

--- a/pytest_httpx/_options.py
+++ b/pytest_httpx/_options.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from typing import Callable
+
+import httpx
 
 
 class _HTTPXMockOptions:
@@ -8,17 +10,9 @@ class _HTTPXMockOptions:
         assert_all_responses_were_requested: bool = True,
         assert_all_requests_were_expected: bool = True,
         can_send_already_matched_responses: bool = False,
-        non_mocked_hosts: Optional[list[str]] = None,
+        should_mock: Callable[[httpx.Request], bool] = lambda request: True,
     ) -> None:
         self.assert_all_responses_were_requested = assert_all_responses_were_requested
         self.assert_all_requests_were_expected = assert_all_requests_were_expected
         self.can_send_already_matched_responses = can_send_already_matched_responses
-
-        if non_mocked_hosts is None:
-            non_mocked_hosts = []
-
-        # Ensure redirections to www hosts are handled transparently.
-        missing_www = [
-            f"www.{host}" for host in non_mocked_hosts if not host.startswith("www.")
-        ]
-        self.non_mocked_hosts = [*non_mocked_hosts, *missing_www]
+        self.should_mock = should_mock

--- a/pytest_httpx/_pretty_print.py
+++ b/pytest_httpx/_pretty_print.py
@@ -24,12 +24,7 @@ class RequestDescription:
             if matcher.headers
             for header in matcher.headers
         }
-        self.expect_body = any(
-            [
-                matcher.content is not None or matcher.json is not None
-                for matcher in matchers
-            ]
-        )
+        self.expect_body = any([matcher.expect_body() for matcher in matchers])
         self.expect_proxy = any([matcher.proxy_url is not None for matcher in matchers])
 
     def __str__(self) -> str:

--- a/pytest_httpx/_pretty_print.py
+++ b/pytest_httpx/_pretty_print.py
@@ -26,6 +26,12 @@ class RequestDescription:
         }
         self.expect_body = any([matcher.expect_body() for matcher in matchers])
         self.expect_proxy = any([matcher.proxy_url is not None for matcher in matchers])
+        self.expected_extensions = {
+            extension
+            for matcher in matchers
+            if matcher.extensions
+            for extension in matcher.extensions
+        }
 
     def __str__(self) -> str:
         request_description = f"{self.request.method} request on {self.request.url}"
@@ -56,5 +62,13 @@ class RequestDescription:
         if self.expect_proxy:
             proxy_url = _proxy_url(self.real_transport)
             extra_description.append(f"{proxy_url if proxy_url else 'no'} proxy URL")
+
+        if self.expected_extensions:
+            present_extensions = {
+                name: value
+                for name, value in self.request.extensions.items()
+                if name in self.expected_extensions
+            }
+            extra_description.append(f"{present_extensions} extensions")
 
         return " and ".join(extra_description)

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -144,7 +144,7 @@ class _RequestMatcher:
                 return False
             # Ensure we re-use the same boundary for comparison
             boundary = boundary_matched.group(1)
-            # TODO move to httpx internals
+            # Prevent internal httpx changes from impacting users not matching on files
             from httpx._multipart import MultipartStream
 
             multipart_content = b"".join(

--- a/pytest_httpx/version.py
+++ b/pytest_httpx/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.32.0"
+__version__ = "0.33.0"


### PR DESCRIPTION
### Added
- Explicit support for python `3.13`.
- `should_mock` option (callable returning a boolean) is now available, defaulting to always returning `True`. Refer to documentation for more details.
- Matching on the full multipart body can now be performed using `match_files` and `match_data` parameters. Refer to documentation for more details.
- Matching on extensions (including timeout) can now be performed using `match_extensions` parameter. Refer to documentation for more details.

### Removed
- `non_mocked_hosts` option is not available anymore. Use `should_mock` instead as in the following sample:
  ```python
  import pytest

  @pytest.mark.httpx_mock(non_mocked_hosts=["my_local_test_host"])
  def test_previous_behavior(httpx_mock):
      ...

  @pytest.mark.httpx_mock(should_mock=lambda request: request.url.host not in ["my_local_test_host"])
  def test_new_behavior(httpx_mock):
      ...
  ```
  Please note that your hosts might need to be prefixed with `www.` depending on your usage.