### PR TITLE
feat: add support for `match_params` allowing partial params matching

### DIFF
--- a/pytest_httpx/_httpx_mock.py
+++ b/pytest_httpx/_httpx_mock.py
@@ -68,6 +68,8 @@ class HTTPXMock:
         :param match_json: JSON decoded HTTP body identifying the request(s) to match. Must be JSON encodable.
         :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
         :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
+        :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
+        :param match_params: HTTP URL query string params of the request(s) to match. Must be a dictionary.
         :param is_optional: True will mark this response as optional, False will expect a request matching it. Must be a boolean. Default to the opposite of assert_all_responses_were_requested option value (itself defaulting to True, meaning this parameter default to False).
         :param is_reusable: True will allow re-using this response even if it already matched, False prevent re-using it. Must be a boolean. Default to the can_send_already_matched_responses option value (itself defaulting to False).
         """
@@ -112,6 +114,7 @@ class HTTPXMock:
         :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
         :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
+        :param match_params: HTTP URL query string params of the request(s) to match. Must be a dictionary.
         :param is_optional: True will mark this callback as optional, False will expect a request matching it. Must be a boolean. Default to the opposite of assert_all_responses_were_requested option value (itself defaulting to True, meaning this parameter default to False).
         :param is_reusable: True will allow re-using this callback even if it already matched, False prevent re-using it. Must be a boolean. Default to the can_send_already_matched_responses option value (itself defaulting to False).
         """
@@ -133,6 +136,7 @@ class HTTPXMock:
         :param match_data: Multipart data (excluding files) identifying the request(s) to match. Must be a dictionary.
         :param match_files: Multipart files identifying the request(s) to match. Refer to httpx documentation for more information on supported values: https://www.python-httpx.org/advanced/clients/#multipart-file-encoding
         :param match_extensions: Extensions identifying the request(s) to match. Must be a dictionary.
+        :param match_params: HTTP URL query string params of the request(s) to match. Must be a dictionary.
         :param is_optional: True will mark this exception response as optional, False will expect a request matching it. Must be a boolean. Default to the opposite of assert_all_responses_were_requested option value (itself defaulting to True, meaning this parameter default to False).
         :param is_reusable: True will allow re-using this exception response even if it already matched, False prevent re-using it. Must be a boolean. Default to the can_send_already_matched_responses option value (itself defaulting to False).
         """

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -24,7 +24,6 @@ def _url_match(
     received_url = received.copy_with(query=None)
     url = url_to_match.copy_with(query=None)
 
-    print(received_params, params, (received_params == params), (url == received_url))
     return (received_params == params) and (url == received_url)
 
 

--- a/tests/test_httpx_async.py
+++ b/tests/test_httpx_async.py
@@ -71,6 +71,18 @@ async def test_url_query_string_matching(httpx_mock: HTTPXMock) -> None:
         response = await client.get("https://test_url?b=2&a=1")
         assert response.content == b""
 
+@pytest.mark.asyncio
+async def test_url_query_string_partial_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=httpx.URL("https://test_url"), match_params = {"a": "1", "b": ANY}, is_reusable=True)
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("https://test_url?a=1&b=2")
+        assert response.content == b""
+
+        # Parameters order should not matter
+        response = await client.get("https://test_url?b=2&a=1")
+        assert response.content == b""
+
 
 @pytest.mark.asyncio
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -64,6 +64,18 @@ def test_url_query_string_matching(httpx_mock: HTTPXMock) -> None:
         assert response.content == b""
 
 
+def test_url_query_string_partial_matching(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=httpx.URL("https://test_url"), match_params = {"a": "1", "b": ANY}, is_reusable=True)
+
+    with httpx.Client() as client:
+        response = client.post("https://test_url?a=1&b=2")
+        assert response.content == b""
+
+        # Parameters order should not matter
+        response = client.get("https://test_url?b=2&a=1")
+        assert response.content == b""
+
+
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
 def test_url_not_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url="https://test_url", is_optional=True)


### PR DESCRIPTION
Hi,

In my company we've have a case where we want to match one parameter of query string and ignore others, right now this is only possible via regex as using `httpx.URL(..., params = ...)` will convert all the `params` to strings, so if we pass something like `{"a": 1, "b": ANY}` we get`{"a": 1, "b": "<ANY>"}`, that does not get matched.

So this PR is adding support for extra keyword argument `match_params` allowing to pass them directly