### PR TITLE
Make match_content JSON comparison whitespace-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Matching on `compact` JSON content is now supported.
 
 ## [0.35.0] - 2024-11-28
 ### Changed

--- a/pytest_httpx/_request_matcher.py
+++ b/pytest_httpx/_request_matcher.py
@@ -135,7 +135,12 @@ class _RequestMatcher:
 
     def _content_match(self, request: httpx.Request) -> bool:
         if self.content is not None:
-            return request.content == self.content
+            try:
+                request_json = json.loads(request.content.decode("utf-8"))
+                expected_json = json.loads(self.content.decode("utf-8"))
+                return request_json == expected_json
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return request.content == self.content
 
         if self.json is not None:
             try:

--- a/tests/test_httpx_sync.py
+++ b/tests/test_httpx_sync.py
@@ -1001,6 +1001,16 @@ def test_content_matching(httpx_mock: HTTPXMock) -> None:
         assert response.read() == b""
 
 
+def test_content_matching_non_bytes(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(match_content=dict(field1="value1", field2="value2"))
+
+    with httpx.Client() as client:
+        response = client.post(
+            "https://test_url", content=dict(field1="value1", field2="value2")
+        )
+        assert response.read() == b""
+
+
 def test_proxy_matching(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(proxy_url="http://user:pwd@my_other_proxy/")
 


### PR DESCRIPTION
Fix: Ensure JSON body matching is whitespace-insensitive

Previously, passing Python dictionaries to `match_content` could result in responses not being mocked as expected, due to differences in whitespace formatting.

This PR resolves the issue by decoding request content using `json.loads`, enabling comparison as native Python objects.

Related to [#3363: JSON request bodies now use a compact representation by default.](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0280-28th-november-2024)

Fix: Ensure JSON object key order does not affect comparison

This update makes JSON body matching in `match_content` order-insensitive by decoding the request content with `json.loads`. Since Python dictionaries (and JSON objects) are inherently unordered, comparing them as native objects ensures that key order does not impact the outcome.

This improves robustness when matching JSON bodies with the same data but different key arrangements.