### PR TITLE
Bump dependencies, update pytest config for pytest 9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Create packages
       run: |
         python -m pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed",


### PR DESCRIPTION
I took a stab at this not knowing much about the project structure. I updated the direct dependency to pytest 9, updated the config structure (no more `.ini_options`) and bumped pytest-asyncio to a version that allows pytest 9 as a transitive dependency.
If we're lucky, skipping multiple versions of pytest-asyncio should not break too many things, at least I remember that from another project, but we also did a few fun things with event loops.

- Bump pytest to 9.0
- Adapt config to pytest 9.0
- Update `pytest-asyncio` to current release
- Drop support for Python 3.9 (EOL)
- Add Python 3.14 to testing matrix